### PR TITLE
Update ivadomed to 2.9.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
     - torchvision==0.9.1+cpu; sys_platform != "darwin"
     - torch==1.8.1;sys_platform == "darwin"
     - torchvision==0.9.1; sys_platform == "darwin"
-    - ivadomed==2.9.3
+    - ivadomed==2.9.4


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR updates the ivadomed dpendency to the newly released version 2.9.4.

The main new features relevant to ADS in the 2.9.4 version are:
- While segmenting, ONNX or PT model are chosen based on device availability (CPU/GPU), ref: https://github.com/ivadomed/ivadomed/pull/1086. The `gpu_id` is `0` by default in `segment_volume`. We could changed that in the future [here](https://github.com/axondeepseg/axondeepseg/blob/6d745492cc091576922b579bc67c56a72905b838/AxonDeepSeg/apply_model.py#L48).
- The `pixel_size_units` options [here](https://github.com/axondeepseg/axondeepseg/blob/6d745492cc091576922b579bc67c56a72905b838/AxonDeepSeg/apply_model.py#L45) now accept `mm` and `nm` in addition of `um`, ref: https://github.com/ivadomed/ivadomed/pull/1025 This will allow us to move forward with issue #597.

I tested the installation on both CPU (my laptop) and GPU (rosenberg) and everything works as expected.
