### PR TITLE
User-friendly message for minimum patch size RuntimeError

### DIFF
--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -50,7 +50,6 @@ def axon_segmentation(
         nii_lst, _ = imed_inference.segment_volume(str(path_model), input_filenames, options=options)
     except RuntimeError as err:
         px_size = options["pixel_size"][0]
-        model_name = Path(path_model).name
         model_json = list(Path(path_model).glob('*.json'))
         with open(str(model_json[0]), 'r') as param_file:
             params = json.load(param_file)

--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -49,6 +49,7 @@ def axon_segmentation(
     try:
         nii_lst, _ = imed_inference.segment_volume(str(path_model), input_filenames, options=options)
     except RuntimeError as err:
+        # check minimum patch size requirement
         px_size = options["pixel_size"][0]
         model_json = list(Path(path_model).glob('*.json'))
         with open(str(model_json[0]), 'r') as param_file:
@@ -64,7 +65,7 @@ def axon_segmentation(
                 msg = (f"The image size must be at least {length_2D}x{length_2D} after resampling to a resolution " 
                     f"of {model_res} um/pixels to create standard sized patches. \nOne of the dimensions of the "
                     f"image has a size of {int(smallest_dim)} after resampling to that resolution. \n"
-                    f"Please use a zoom factor greater or equal to {min_zoom:.2f} to successfully apply this model.")
+                    f"Please use a zoom factor greater or equal to {min_zoom:.2f} using the `-z` option to successfully apply this model.")
                 raise RuntimeError(msg) from err
         raise
     

--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -58,12 +58,14 @@ def axon_segmentation(
         for file in input_filenames:
             img = ads.imread(file)
             resampled = [size * px_size / model_res for size in img.shape]
-            for r in resampled:
-                if r < length_2D:
-                    raise RuntimeError(
-                        f"The image size must be at least {length_2D}x{length_2D} after resampling to a resolution "
-                        f"of {model_res} um/pixels to create standard sized patches. One of the dimensions of the " 
-                        f"image has a size of {int(r)} after resampling to that resolution.") from err
+            smallest_dim = sorted(resampled)[0]
+            if smallest_dim < length_2D:
+                min_zoom = length_2D / smallest_dim
+                msg = (f"The image size must be at least {length_2D}x{length_2D} after resampling to a resolution " 
+                    f"of {model_res} um/pixels to create standard sized patches. \nOne of the dimensions of the "
+                    f"image has a size of {int(smallest_dim)} after resampling to that resolution. \n"
+                    f"Please use a zoom factor greater or equal to {min_zoom:.2f} to successfully apply this model.")
+                raise RuntimeError(msg) from err
         raise
     
     target_lst = [str(axon_suffix), str(myelin_suffix)]

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -212,3 +212,11 @@ class TestCore(object):
             AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imageFolderPath), "-v", "1"])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 3)
+
+    @pytest.mark.exceptionhandling
+    def test_main_cli_handles_exception_patch_size_too_small(self):
+
+        with pytest.raises(RuntimeError) as pytest_wrapped_e:
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-s", "0.05"])
+
+        assert "The image size must be at least" in str(pytest_wrapped_e.value)


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
This PR aims at notifying the user when his image_size/pixel_size is resampled to something smaller than the model's minimum patch size. As noted in #604, the most recent occurence of this problem, a user-friendly message was displayed when this happened in v3. The message I added is very similar to the old one.

In general, I think we want to avoid such checks:
```python
try:
    nii_lst, _ = imed_inference.segment_volume(...)
except RuntimeError as err:
    if err.message == '"length_2D" must be smaller or equal to image dimensions after resampling.':
        # do something
```
Because the error is thrown from the ivadomed side. If someone changes one letter of this string, we don't catch it anymore. So its not super pretty but this is why I compute the resampled size in the `apply_model.py` file directly in the except clause.

Here is the output now:
```bash
» axondeepseg -t BF -i LM_58_G.tif -s 0.0064                                                                                 1 ↵ herman@tank
AxonDeepSeg v.4.0.0
2022-03-17 12:10:44.746 | INFO     | ivadomed.config_manager:_display_differing_keys:153 - Adding the following keys to the configuration file
2022-03-17 12:10:44.746 | INFO     | ivadomed.config_manager:deep_dict_compare:44 -     loader_parameters: patch_filter_params: {'filter_empty_mask': False, 'filter_empty_input': False}
2022-03-17 12:10:44.746 | INFO     | ivadomed.config_manager:_display_differing_keys:155 - 

2022-03-17 12:10:44.747 | WARNING  | ivadomed.inference:segment_volume:402 - fname_roi has not been specified, then the entire volume is processed.
Traceback (most recent call last):
  File "/home/herman/Documents/NEUROPOLY_21/axondeepseg/AxonDeepSeg/apply_model.py", line 50, in axon_segmentation
    nii_lst, _ = imed_inference.segment_volume(str(path_model), input_filenames, options=options)
  File "/home/herman/.conda/envs/ads_v4_venv/lib/python3.8/site-packages/ivadomed/inference.py", line 446, in segment_volume
    ds.load_filenames()
  File "/home/herman/.conda/envs/ads_v4_venv/lib/python3.8/site-packages/ivadomed/loader/mri2d_segmentation_dataset.py", line 137, in load_filenames
    self.prepare_indices()
  File "/home/herman/.conda/envs/ads_v4_venv/lib/python3.8/site-packages/ivadomed/loader/mri2d_segmentation_dataset.py", line 152, in prepare_indices
    raise RuntimeError('"length_2D" must be smaller or equal to image dimensions after resampling.')
RuntimeError: "length_2D" must be smaller or equal to image dimensions after resampling.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/herman/.conda/envs/ads_v4_venv/bin/axondeepseg", line 33, in <module>
    sys.exit(load_entry_point('AxonDeepSeg', 'console_scripts', 'axondeepseg')())
  File "/home/herman/Documents/NEUROPOLY_21/axondeepseg/AxonDeepSeg/segment.py", line 276, in main
    segment_image(
  File "/home/herman/Documents/NEUROPOLY_21/axondeepseg/AxonDeepSeg/segment.py", line 112, in segment_image
    axon_segmentation(path_acquisitions_folders=path_acquisition, acquisitions_filenames=[str(path_acquisition / acquisition_name)],
  File "/home/herman/Documents/NEUROPOLY_21/axondeepseg/AxonDeepSeg/apply_model.py", line 64, in axon_segmentation
    raise RuntimeError(
RuntimeError: The image size must be at least 512x512 after resampling to a resolution of 0.1 um/pixels to create standard sized patches. One of the dimensions of the image has a size of 92 after resampling to that resolution.

```

Eventually we could mention the zoom factor option (#609) in the error message to point the user towards a potential solution.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #615 