### PR TITLE
Zoom factor option for segmentation via CLI

### DIFF
--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -219,6 +219,10 @@ def main(argv=None):
                                                             'Default value: '+str(default_overlap)+'\n'+
                                                             'Recommended range of values: [10-100]. \n',
                                                             default=default_overlap)
+    ap.add_argument("-z", "--zoom", required=False, help='Zoom factor to adjust the acquired pixel size of the image(s). \n'+
+                                                            'The pixel size used for the segmentation will be the product of the \n'+
+                                                            'specified pixel size and the zoom factor.',
+                                                            default=None)
     ap._action_groups.reverse()
 
     # Processing the arguments
@@ -232,6 +236,10 @@ def main(argv=None):
         psm = None
     path_target_list = [Path(p) for p in args["imgpath"]]
     new_path = Path(args["model"]) if args["model"] else None 
+    if args["zoom"] is not None:
+        zoom_factor = float(args["zoom"])
+    else:
+        zoom_factor = 1.0
 
     # Preparing the arguments to axon_segmentation function
     path_model = generate_default_parameters(type_, new_path)
@@ -277,7 +285,7 @@ def main(argv=None):
                     path_testing_image=current_path_target,
                     path_model=path_model,
                     overlap_value=overlap_value,
-                    acquired_resolution=psm,
+                    acquired_resolution=psm * zoom_factor,
                     verbosity_level=verbosity_level
                     )
 
@@ -312,7 +320,7 @@ def main(argv=None):
                 path_testing_images_folder=current_path_target,
                 path_model=path_model,
                 overlap_value=overlap_value,
-                acquired_resolution=psm,
+                acquired_resolution=psm * zoom_factor,
                 verbosity_level=verbosity_level
                 )
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
This PR adds a zoom factor option for CLI segmentation.
This is a very minimal implementation. For #610, if we want to do a sweep on a range of zoom factor values, this option wouldn't even be used because we would be more likely to use `segment.py:segment_image()`.

Still need to update the documentation. Also, any comment on the help message of the argument is welcome.

```
» axondeepseg --help                                                                                              herman@tank
AxonDeepSeg v.4.0.0
usage: axondeepseg [-h] -t {SEM,TEM,BF} -i IMGPATH [IMGPATH ...] [-m MODEL] [-s SIZEPIXEL] [-v {0,1}] [--overlap OVERLAP] [-z ZOOM]

required arguments:
[...]

optional arguments:
[...]
  -z ZOOM, --zoom ZOOM  Zoom factor to adjust the acquired pixel size of the image(s). 
                        The pixel size used for the segmentation will be the product of the 
                        specified pixel size and the zoom factor.

```

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #609 
Also, this feature should be mentioned in #619 when the RuntimeError related to minimum patch size occurs.