### PR TITLE
Fix morphometrics bug when writing index/axonmyelin_index files

### DIFF
--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -238,8 +238,7 @@ def main(argv=None):
                     
                 print(f"Morphometrics file: {morph_filename} has been saved in the {str(current_path_target.parent.absolute())} directory")
             except IOError:
-                print("Cannot save morphometrics data in file '%s'." % morph_filename)
-                raise
+                print(f"Cannot save morphometrics data or associated index images for file {morph_filename}.")
 
         else: 
             print("The path(s) specified is/are not image(s). Please update the input path(s) and try again.")

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -222,13 +222,16 @@ def main(argv=None):
                     pd.DataFrame(x).to_csv(current_path_target.parent / morph_filename, na_rep='NaN')
 
                 # Generate the index image
-                indexes_outfile = current_path_target.parent /(str(current_path_target.with_suffix("")) +
-                                                              str(index_suffix))
-                ads.imwrite(indexes_outfile, index_image_array)
+                if str(current_path_target) == str(current_path_target.parts[-1]):
+                    outfile_basename = current_path_target.parent / str(current_path_target.with_suffix(""))
+                else:
+                    # in case current_path_target already contains the parent directory
+                    outfile_basename = str(current_path_target.with_suffix(""))
+
+                ads.imwrite(outfile_basename + str(index_suffix), index_image_array)
                 # Generate the colored image
                 postprocessing.generate_and_save_colored_image_with_index_numbers(
-                    filename=current_path_target.parent /(str(current_path_target.with_suffix("")) +
-                                                          str(axonmyelin_index_suffix)),
+                    filename=outfile_basename + str(axonmyelin_index_suffix),
                     axonmyelin_image_path=str(current_path_target.with_suffix("")) + str(axonmyelin_suffix),
                     index_image_array=index_image_array
                 )
@@ -236,6 +239,7 @@ def main(argv=None):
                 print(f"Morphometrics file: {morph_filename} has been saved in the {str(current_path_target.parent.absolute())} directory")
             except IOError:
                 print("Cannot save morphometrics data in file '%s'." % morph_filename)
+                raise
 
         else: 
             print("The path(s) specified is/are not image(s). Please update the input path(s) and try again.")

--- a/test/morphometrics/test_launch_morphometrics_computation.py
+++ b/test/morphometrics/test_launch_morphometrics_computation.py
@@ -171,7 +171,7 @@ class TestCore(object):
         # unlink the morphometrics file
         morphometricsPathCopy.unlink() 
 
-    @pytest.mark.unit 
+    @pytest.mark.unit
     def test_main_cli_runs_successfully_for_generating_batches_morphometrics_multiple_images(self):
         
         # path of `__test_demo_files__` directory
@@ -189,12 +189,18 @@ class TestCore(object):
 
         morphometricsImagePathCopy = self.dataPath.parent / '__test_demo_files_copy__' / self.morphometricsFile # morphometrics file of `image.png` image
         morphometricsImgPathCopy = self.dataPath.parent / '__test_demo_files_copy__' / ('img' + '_' + str(morph_suffix)) # morphometrics file of `img.png` image
+        indexImagePathCopy = self.dataPath.parent / '__test_demo_files_copy__' / ('image_axonmyelin_index.png') # index image
+        indexImgPathCopy = self.dataPath.parent / '__test_demo_files_copy__' / ('img_axonmyelin_index.png') # index image
 
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             AxonDeepSeg.morphometrics.launch_morphometrics_computation.main(["-i", str(pathDirCopy)])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0) and morphometricsImagePathCopy.exists() and morphometricsImgPathCopy.exists()
         
+        # Assert that the index images are created.
+        assert indexImagePathCopy.exists()
+        assert indexImgPathCopy.exists()
+
         # unlink the morphometrics file
         morphometricsImagePathCopy.unlink() 
         morphometricsImgPathCopy.unlink() 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
Tying up some loose ends here. This PR addresses a bug when using the `axondeepseg_morphometrics` command with the `-i` arg pointing to a *folder*. In these cases, the xlsx/csv file was correctly written but the index + axonmyelin_index images could not be saved. Note that when launching the script from the actual directory and using `-i .`, this behavior does not manifest.

Also, the related exception was poorly handled and actually ignored. Not sure if this is the desired behavior (maybe when doing morphometrics for multiple files it's useful to ignore the exception and go on to the next folder?) I changed it but now the catch block is useless.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #553 