### PR TITLE
Update ivadomed to 2.9.5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
     - torchvision==0.9.1+cpu; sys_platform != "darwin"
     - torch==1.8.1;sys_platform == "darwin"
     - torchvision==0.9.1; sys_platform == "darwin"
-    - ivadomed==2.9.4
+    - ivadomed==2.9.5


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR updates the ivadomed dependency to the newly released version 2.9.5.

This new version fix the loading of 16bit grayscale TIF files (related to #617).
I'm not closing the issue yet since we still need to add tests on ADS side for this.
