### PR TITLE
Zoom factor sweep

### DIFF
--- a/AxonDeepSeg/zoom_factor_sweep.py
+++ b/AxonDeepSeg/zoom_factor_sweep.py
@@ -1,0 +1,52 @@
+# Successively segments an image with zoom factors within a given range
+
+from pathlib import Path
+from AxonDeepSeg.segment import segment_image
+from config import axonmyelin_suffix, axon_suffix, myelin_suffix
+
+
+def sweep(
+    path_image,
+    path_model,
+    overlap_value,
+    sweep_range,
+    sweep_length,
+    acquired_resolution = None,
+    ):
+    """
+    Wrapper over segment_image to produce segmentations for zoom factor values within a given range.
+    :param path_image:          the path of the image to segment.
+    :param path_model:          where to access the model
+    :param overlap_value:       the number of pixels to be used for overlap when doing prediction. Higher
+                                value means less border effects but longer segmentation time.
+    :param sweep_range:         upper and lower bounds of the zoom factor range
+    :param sweep_length:        number of equidistant zoom factor values to sample from the range
+    :param acquired_resolution: isotropic pixel resolution of the acquired images.
+    :return: Nothing.
+    """
+
+    lower_bound, upper_bound = sweep_range
+    # create new directory to store segmentations
+    path_results = Path(path_image).parent.absolute() / 'sweep_results'
+    path_results.mkdir(parents=True, exist_ok=True)
+    path_seg_outputs = [
+        Path(path_image).stem + str(axon_suffix),
+        Path(path_image).stem + str(myelin_suffix),
+        Path(path_image).stem + str(axonmyelin_suffix),
+    ]
+
+    for i in range(sweep_length):
+        zoom_factor = lower_bound + i * (upper_bound - lower_bound) / sweep_length
+        segment_image(
+            path_image,
+            path_model,
+            overlap_value,
+            acquired_resolution,
+            zoom_factor,
+        )    
+        # move and rename segmentations
+        for path_seg in path_seg_outputs:
+            path = Path(path_seg)
+            path.rename(path_results / Path(path.stem + f'_zf-{zoom_factor}.png'))
+
+        print(f"Done with zoom factor {zoom_factor}.")


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
The goal of this PR is to add a feature to repeatedly segment the same image using different zoom factors within a given range, as discussed in #610. This tool will be useful to evaluate an appropriate zoom factor for optimal segmentation visual aspect.

I added the feature in a new file but the sweep function will be called from the main `segment.py` CLI. For now, having this feature in a separate file does not make much sense because the code is pretty short but, eventually, when we add a metric to evaluate the masks produced, it will be helpful.

Current parameters: 
- `sweep_range` (e.g. [3, 5] for zoom factors between 3 and 5)
- `sweep_length`: number of equidistant zoom factors to sample in sweep_range

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
#610 