### PR TITLE
Add logging for segmentation/morphometrics

### DIFF
--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -222,7 +222,7 @@ def download_data(url_data):
     return 0
 
 def convert_path(object_path):
-    """ Convert path
+    """
     Convert path or list of paths to Path() objects.
     If None type, returns None.
 

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -361,7 +361,7 @@ def load_axon_morphometrics(morphometrics_file):
         else:
             stats_dataframe = pd.read_pickle(morphometrics_file)
     except IOError as e:
-        print(("\nError: Could not load file \"{0}\"\n".format(morphometrics_file)))
+        logger.error(f"Error: Could not load file {str(morphometrics_file)}")
         raise
 
     stats_dataframe = rename_column_names_after_loading(stats_dataframe)
@@ -496,6 +496,6 @@ def write_aggregate_morphometrics(path_folder, aggregate_metrics):
         with open(path_folder / 'aggregate_morphometrics.txt', 'w') as text_file:
             text_file.write('aggregate_metrics: ' + repr(aggregate_metrics) + '\n')
     except IOError as e:
-        print(("\nError: Could not save file \"{0}\" in "
-               "directory \"{1}\".\n".format('aggregate_morphometrics.txt', path_folder)))
+        msg = f"Error: Could not save file \"aggregate_morphometrics.txt\" in directory \"{path_folder}\"."
+        logger.error(msg)
         raise

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -7,6 +7,7 @@ from matplotlib import image
 import sys
 import os
 from tqdm import tqdm
+from loguru import logger
 
 # Scientific modules imports
 import numpy as np
@@ -114,6 +115,9 @@ def main(argv=None):
     flag_morp_batch = False # True, if batch moprhometrics is to computed else False
     target_list = []        # list of image paths for batch morphometrics computations
 
+    logger.add("axondeepseg.log", level='INFO')
+    logger.info(f'Logging initialized for morphometrics in "{os.getcwd()}".')
+
     for dir_iter in path_target_list:
         if dir_iter.is_dir(): # batch morphometrics
             flag_morp_batch = True
@@ -132,20 +136,20 @@ def main(argv=None):
             if (Path(str(current_path_target.with_suffix("")) + str(axon_suffix))).exists():
                 pred_axon = image.imread(str(current_path_target.with_suffix("")) + str(axon_suffix))
             else:
-                print(f"ERROR: Segmented axon mask for image: `{str(current_path_target)}` is not present in the image folder. ",
-                            "Please check that the axon mask is located in the image folder. ",
-                            "If it is not present, perform segmentation of the image first using ADS.\n"
-                    )
+                msg = f"ERROR: Segmented axon mask for image: `{str(current_path_target)}` is not present " \
+                    "in the image folder. Please check that the axon mask is located in the image folder. " \
+                    "If it is not present, perform segmentation of the image first using ADS.\n"
+                logger.error(msg)
                 sys.exit(3)
 
             # load myelin mask
             if (Path(str(current_path_target.with_suffix("")) + str(myelin_suffix))).exists():
                 pred_myelin = image.imread(str(current_path_target.with_suffix("")) + str(myelin_suffix))
             else:
-                print(f"ERROR: Segmented myelin mask for image: `{str(current_path_target)}` is not present in the image folder. ",
-                            "Please check that the myelin mask is located in the image folder. ",
-                            "If it is not present, perform segmentation of the image first using ADS.\n"
-                    )
+                msg = f"ERROR: Segmented myelin mask for image: `{str(current_path_target)}` is not present " \
+                    "in the image folder. Please check that the myelin mask is located in the image folder. " \
+                    "If it is not present, perform segmentation of the image first using ADS.\n"
+                logger.error(msg)
                 sys.exit(3)
 
             if args["sizepixel"] is not None:
@@ -160,10 +164,10 @@ def main(argv=None):
                     psm = float(resolution_file.read())
                 else:
 
-                    print(f"ERROR: No pixel size is provided, and there is no pixel_size_in_micrometer.txt file for image: `{str(current_path_target)}` in the image folder. ",
-                                "Please provide a pixel size (using argument -s), or add a pixel_size_in_micrometer.txt file ",
-                                "containing the pixel size value.\n"
-                        )
+                    msg = "ERROR: No pixel size is provided, and there is no pixel_size_in_micrometer.txt file for " \
+                        f"image: `{str(current_path_target)}` in the image folder. Please provide a pixel size (using " \
+                        "argument -s), or add a pixel_size_in_micrometer.txt file containing the pixel size value.\n"
+                    logger.error(msg)
                     sys.exit(3)
 
             x = params.column_names
@@ -221,12 +225,15 @@ def main(argv=None):
                     index_image_array=index_image_array
                 )
 
-                print(f"Morphometrics file: {morph_filename} has been saved in the {str(current_path_target.parent.absolute())} directory")
+                logger.info("Morphometrics file: {} has been saved in the {} directory",
+                    morph_filename,
+                    str(current_path_target.parent.absolute()),
+                )
             except IOError:
-                print(f"Cannot save morphometrics data or associated index images for file {morph_filename}.")
+                logger.warning(f"Cannot save morphometrics data or associated index images for file {morph_filename}.")
 
         else:
-            print("The path(s) specified is/are not image(s). Please update the input path(s) and try again.")
+            logger.warning("The path(s) specified is/are not image(s). Please update the input path(s) and try again.")
             break
     sys.exit(0)
 

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -115,7 +115,7 @@ def main(argv=None):
     flag_morp_batch = False # True, if batch moprhometrics is to computed else False
     target_list = []        # list of image paths for batch morphometrics computations
 
-    logger.add("axondeepseg.log", level='INFO', enqueue=True)
+    logger.add("axondeepseg.log", level='DEBUG', enqueue=True)
     logger.info(f'Logging initialized for morphometrics in "{os.getcwd()}".')
 
     for dir_iter in path_target_list:

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -240,4 +240,5 @@ def main(argv=None):
 
 # Calling the script
 if __name__ == '__main__':
-    main()
+    with logger.catch():
+        main()

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -115,7 +115,7 @@ def main(argv=None):
     flag_morp_batch = False # True, if batch moprhometrics is to computed else False
     target_list = []        # list of image paths for batch morphometrics computations
 
-    logger.add("axondeepseg.log", level='INFO')
+    logger.add("axondeepseg.log", level='INFO', enqueue=True)
     logger.info(f'Logging initialized for morphometrics in "{os.getcwd()}".')
 
     for dir_iter in path_target_list:

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -317,7 +317,7 @@ def main(argv=None):
         2: Invalid argument value
         3: Missing value or file
     '''
-    logger.add("axondeepseg.log", level='INFO')
+    logger.add("axondeepseg.log", level='INFO', enqueue=True)
     logger.info(f"AxonDeepSeg v.{AxonDeepSeg.__version__}")
 
     ap = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -452,4 +452,5 @@ def main(argv=None):
 
 # Calling the script
 if __name__ == '__main__':
-    main()
+    with logger.catch():
+        main()

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -424,7 +424,7 @@ def main(argv=None):
         sweep_range = [float(args["sweeprange"][0]), float(args["sweeprange"][1])]
         sweep_length = int(args["sweeplength"])
         if len(path_target_list) != 1:
-            print("ERROR: Please use a single image for zoom factor sweep.")
+            logger.error("Error: Please use a single image for zoom factor sweep.")
             sys.exit(5)
 
     # Preparing the arguments to axon_segmentation function
@@ -491,7 +491,7 @@ def main(argv=None):
 
         else:
             if sweep_mode:
-                print("ERROR: Please use a single image for zoom factor sweep.")
+                logger.error("Error: Please use a single image for zoom factor sweep.")
                 sys.exit(5)
 
             # Handle cases if no resolution is provided on the CLI

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -315,8 +315,9 @@ def main(argv=None):
     Main loop.
     :return: Exit code.
         0: Success
-        2: Invalid argument value
         3: Missing value or file
+        4: Invalid acquired resolution
+        5: Too many input files
     '''
     logger.add("axondeepseg.log", level='INFO', enqueue=True)
     logger.info(f"AxonDeepSeg v.{AxonDeepSeg.__version__}")

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -319,7 +319,7 @@ def main(argv=None):
         4: Invalid acquired resolution
         5: Too many input files
     '''
-    logger.add("axondeepseg.log", level='INFO', enqueue=True)
+    logger.add("axondeepseg.log", level='DEBUG', enqueue=True)
     logger.info(f"AxonDeepSeg v.{AxonDeepSeg.__version__}")
 
     ap = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)

--- a/AxonDeepSeg/zoom_factor_sweep.py
+++ b/AxonDeepSeg/zoom_factor_sweep.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from math import ceil
+from loguru import logger
 
 import AxonDeepSeg.segment as ads_seg
 from AxonDeepSeg import ads_utils
@@ -69,11 +70,11 @@ def sweep(
             path = Path(path_seg)
             path.rename(path_results / Path(path.stem + f'_zf-{zoom_factor}.png'))
 
-        print(f"Done with zoom factor {zoom_factor}.")
+        logger.info(f"Done with zoom factor {zoom_factor}.")
 
     if invalid_lower_bound:
         warning_msg = "WARNING: The range specified contained invalid zoom factor values, so the lower bound "\
             f"was adjusted. Less than {sweep_length} zoom factor values were processed."
-        print(warning_msg)
+        logger.warning(warning_msg)
 
 

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -289,6 +289,8 @@ Then, use the following command::
 
     axondeepseg -t SEM -i test_segmentation/test_sem_image/image1_sem/
 
+Please note that when using ``axondeepseg``, a file called *axondeepseg.log* will be saved in the current working directory. The console output will be saved in this file so you can review it later (useful to process large folders).
+
 Segment images from multiple folders
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -438,6 +440,8 @@ This will generate **'77_axon_morphometrics.xlsx'** and **'78_axon_morphometrics
     ---- image2_axon_morphometrics.xlsx
     
     ---- pixel_size_in_micrometer.txt 
+
+Please note that when using the ``axondeepseg_morphometrics`` command, the console output will be logged in a file called *axondeepseg.log* in the current working directory.
     
 Axon Shape: Circle vs Ellipse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/morphometrics/test_launch_morphometrics_computation.py
+++ b/test/morphometrics/test_launch_morphometrics_computation.py
@@ -31,8 +31,9 @@ class TestCore(object):
         if self.morphometricsPath.exists():
             self.morphometricsPath.unlink()
 
-        if Path('axondeepseg.log').exists():
-            Path('axondeepseg.log').unlink()
+        logfile = self.testPath / 'axondeepseg.log'
+        if logfile.exists():
+            logfile.unlink()
 
     # --------------launch_morphometrics_computation tests-------------- #
     @pytest.mark.unit

--- a/test/morphometrics/test_launch_morphometrics_computation.py
+++ b/test/morphometrics/test_launch_morphometrics_computation.py
@@ -31,6 +31,9 @@ class TestCore(object):
         if self.morphometricsPath.exists():
             self.morphometricsPath.unlink()
 
+        if Path('axondeepseg.log').exists():
+            Path('axondeepseg.log').unlink()
+
     # --------------launch_morphometrics_computation tests-------------- #
     @pytest.mark.unit
     def test_launch_morphometrics_computation_saves_expected_files(self):
@@ -263,3 +266,12 @@ class TestCore(object):
         ads.imwrite(str(pathAxon), axonMask)
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 3)
+
+    @pytest.mark.integration
+    def test_main_cli_creates_logfile(self):
+        pathImg = self.dataPath / 'image.png'
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.morphometrics.launch_morphometrics_computation.main(["-s", "0.07", "-i", str(pathImg), "-f", str(morph_suffix)])
+
+        assert Path('axondeepseg.log').exists()

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -120,7 +120,8 @@ class TestCore(object):
         outputFiles = [
             'image' + str(axon_suffix),
             'image' + str(myelin_suffix),
-            'image' + str(axonmyelin_suffix)
+            'image' + str(axonmyelin_suffix),
+            'segment_folders.log',
             ]
 
         segment_folders(

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -121,7 +121,7 @@ class TestCore(object):
             'image' + str(axon_suffix),
             'image' + str(myelin_suffix),
             'image' + str(axonmyelin_suffix),
-            'segment_folders.log',
+            'axondeepseg.log',
             ]
 
         segment_folders(

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -395,16 +395,3 @@ class TestCore(object):
             AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.37"])
 
         assert Path('axondeepseg.log').exists()
-
-    @pytest.mark.integration
-    def test_main_cli_creates_logfile_in_working_directory(self):
-        
-        saved_dir = Path.cwd()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            os.chdir(tmpdir)
-            with pytest.raises(SystemExit) as pytest_wrapped_e:
-                AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-s", "0.37"])
-
-            logfile = Path(tmpdir) / 'axondeepseg.log'
-            assert logfile.exists()
-            os.chdir(saved_dir)

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -102,6 +102,8 @@ class TestCore(object):
             'image_2.nii.gz'
             ]
 
+        logfile = testPath / 'axondeepseg.log'
+
         for fileName in outputFiles:
 
             if (imageFolderPath / fileName).exists():
@@ -110,8 +112,8 @@ class TestCore(object):
             if (imageFolderPathWithPixelSize / fileName).exists():
                 (imageFolderPathWithPixelSize / fileName).unlink()
         
-        if Path('axondeepseg.log').exists():
-            Path('axondeepseg.log').unlink()
+        if logfile.exists():
+            logfile.unlink()
 
     # --------------segment_folders tests-------------- #
     @pytest.mark.integration

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -109,6 +109,9 @@ class TestCore(object):
 
             if (imageFolderPathWithPixelSize / fileName).exists():
                 (imageFolderPathWithPixelSize / fileName).unlink()
+        
+        if Path('axondeepseg.log').exists():
+            Path('axondeepseg.log').unlink()
 
     # --------------segment_folders tests-------------- #
     @pytest.mark.integration
@@ -121,7 +124,6 @@ class TestCore(object):
             'image' + str(axon_suffix),
             'image' + str(myelin_suffix),
             'image' + str(axonmyelin_suffix),
-            'axondeepseg.log',
             ]
 
         segment_folders(
@@ -189,7 +191,7 @@ class TestCore(object):
         outputFiles = [
             'image' + str(axon_suffix),
             'image' + str(myelin_suffix),
-            'image' + str(axonmyelin_suffix)
+            'image' + str(axonmyelin_suffix),
             ]
 
         segment_image(
@@ -333,3 +335,11 @@ class TestCore(object):
             AxonDeepSeg.segment.main(["-t", "TEM", "-i", str(self.imageZoomFolderWithPixelSize), "-v", "1", "-z", "1.2"])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
+
+    @pytest.mark.integration
+    def test_main_cli_creates_logfile(self):
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.37"])
+
+        assert Path('axondeepseg.log').exists()

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 import shutil
+import tempfile
+import os
 
 import pytest
 
@@ -101,8 +103,7 @@ class TestCore(object):
             'image_2' + str(axon_suffix),
             'image_2' + str(myelin_suffix),
             'image_2' + str(axonmyelin_suffix),
-            'image_2.nii.gz',
-            'axondeepseg.log'
+            'image_2.nii.gz'
             ]
 
         logfile = testPath / 'axondeepseg.log'
@@ -396,10 +397,14 @@ class TestCore(object):
         assert Path('axondeepseg.log').exists()
 
     @pytest.mark.integration
-    def test_main_cli_creates_logfile_in_working_directory(self, monkeypatch: pytest.MonkeyPatch):
+    def test_main_cli_creates_logfile_in_working_directory(self):
         
-        monkeypatch.chdir(self.imageFolderPath)
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            AxonDeepSeg.segment.main(["-t", "SEM", "-i", "image.png", "-s", "0.37"])
-        
-        assert Path(self.imageFolderPath / "axondeepseg.log").exists()
+        saved_dir = Path.cwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            with pytest.raises(SystemExit) as pytest_wrapped_e:
+                AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-s", "0.37"])
+
+            logfile = Path(tmpdir) / 'axondeepseg.log'
+            assert logfile.exists()
+            os.chdir(saved_dir)

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -101,7 +101,8 @@ class TestCore(object):
             'image_2' + str(axon_suffix),
             'image_2' + str(myelin_suffix),
             'image_2' + str(axonmyelin_suffix),
-            'image_2.nii.gz'
+            'image_2.nii.gz',
+            'axondeepseg.log'
             ]
 
         logfile = testPath / 'axondeepseg.log'
@@ -344,14 +345,6 @@ class TestCore(object):
             AxonDeepSeg.segment.main(["-t", "TEM", "-i", str(self.imageZoomFolderWithPixelSize), "-v", "1", "-z", "1.2"])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
-
-    @pytest.mark.integration
-    def test_main_cli_creates_logfile(self):
-
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.37"])
-
-        assert Path('axondeepseg.log').exists()
     
     @pytest.mark.integration
     def test_main_cli_zoom_factor_sweep_creates_expected_files(self):
@@ -393,3 +386,20 @@ class TestCore(object):
             AxonDeepSeg.segment.main(["-t", "SEM", "-i", badFolder, "-r", "1", "1.4", "-l", "4"])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 5)
+
+    @pytest.mark.integration
+    def test_main_cli_creates_logfile(self):
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.37"])
+
+        assert Path('axondeepseg.log').exists()
+
+    @pytest.mark.integration
+    def test_main_cli_creates_logfile_in_working_directory(self, monkeypatch: pytest.MonkeyPatch):
+        
+        monkeypatch.chdir(self.imageFolderPath)
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", "image.png", "-s", "0.37"])
+        
+        assert Path(self.imageFolderPath / "axondeepseg.log").exists()


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The goal of this PR is to add some form of logging for batch processing, more specifically:
- [x] batch segmentation (basically log everything inside the `segment_folders()` function)
- [x] batch morphometrics

I tried using python's native `logging` module but it's somewhat complex to use and, for some reason, suppresses ivadomed's output. `loguru`, on the other hand, is much simpler, the output is much nicer and everything works out of the box with almost 0 boilerplate. Here is a screenshot of what it looks like. As you can see, it looks very similar to ivadomed's output.
![Screenshot_20220504_161055](https://user-images.githubusercontent.com/83031821/166817832-c7546228-dee2-4f68-8b35-f6cf716a13a9.png)

As of now, the behavior is to create a *axondeepseg.log* file in the working directory or open it if it already exists, then append the recorded message (info/warning/error).

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #627 