### PR TITLE
Refactor the data structure used for storing morphometrics

### DIFF
--- a/AxonDeepSeg/download_tests.py
+++ b/AxonDeepSeg/download_tests.py
@@ -10,7 +10,7 @@ def download_tests(destination=None):
         destination = convert_path(destination)
         test_files_destination = destination / "__test_files__"
 
-    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20220323b.zip"  
+    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20220522a.zip"  
     files_before = list(Path.cwd().iterdir())
 
     if (

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -144,7 +144,7 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
 
         # Deal with myelin
         if im_myelin is not None:
-            # Delcare the statistics to add for the myelin and add them to the stats dictionary
+            # Declare the statistics to add for the myelin and add them to the stats dictionary
             myelin_stats = {
                 'gratio': np.nan,
                 'myelin_thickness': np.nan,

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -190,7 +190,7 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                     "centroid [y:{0}, x:{1}]".format(y0, x0)
                     )
         # Add the stats to the dataframe
-        # TODO: should I use float32 as a datatype?
+        # Question: should we use float32 as a datatype?
         if stats_dataframe.empty:
             stats_dataframe = pd.DataFrame(stats, index=[0]) # First iteration
         else:
@@ -511,16 +511,3 @@ def write_aggregate_morphometrics(path_folder, aggregate_metrics):
         print(("\nError: Could not save file \"{0}\" in "
                "directory \"{1}\".\n".format('aggregate_morphometrics.txt', path_folder)))
         raise
-
-
-if __name__ == "__main__":
-    # This section is for testing purposes
-    from AxonDeepSeg import ads_utils
-    image_path = "C:\\Users\\Stoyan\\Desktop\\ADS\\generated_touching_myelin.png"
-    image_to_filter = ads_utils.imread(image_path)
-    axon_mask, myelin_mask = ads_utils.extract_axon_and_myelin_masks_from_image_data(image_to_filter)
-    morphs, b_image = get_axon_morphometrics(im_axon=axon_mask, im_myelin=myelin_mask, pixel_size=1.0, return_index_image=True)
-    save_path = "C:\\Users\\Stoyan\\PycharmProjects\\ads_project5\\morphs_save.xlsx"
-    save_axon_morphometrics(save_path, morphs)
-    morphs2 = load_axon_morphometrics(save_path)
-    print("Test")

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -139,12 +139,7 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                  'axon_perimeter': axon_perimeter,
                  'solidity': solidity,
                  'eccentricity': eccentricity,
-                 'orientation': orientation, 
-                 'gratio': np.nan,
-                 'myelin_thickness': np.nan,
-                 'myelin_area': np.nan,
-                 'axonmyelin_area': np.nan,
-                 'axonmyelin_perimeter': np.nan
+                 'orientation': orientation
                  }
 
         # Deal with myelin

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -144,6 +144,15 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
 
         # Deal with myelin
         if im_myelin is not None:
+            # Delcare the statistics to add for the myelin and add them to the stats dictionary
+            myelin_stats = {
+                'gratio': np.nan,
+                'myelin_thickness': np.nan,
+                'myelin_area': np.nan,
+                'axonmyelin_area': np.nan,
+                'axonmyelin_perimeter': np.nan
+            }
+            stats.update(myelin_stats)
             # Find label of axonmyelin corresponding to axon centroid
             label_axonmyelin = im_axonmyelin_label[int(y0), int(x0)]
 

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -193,7 +193,7 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
         if stats_dataframe.empty:
             stats_dataframe = pd.DataFrame(stats, index=[0]) # First iteration
         else:
-            stats_dataframe = pd.concat([stats_dataframe, pd.DataFrame(stats, index=[0], ignore_index=True)
+            stats_dataframe = pd.concat([stats_dataframe, pd.DataFrame(stats, index=[0])], ignore_index=True)
 
     if return_index_image is True:
         # Extract the information required to generate the index image

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -191,9 +191,9 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                     )
         # Add the stats to the dataframe
         if stats_dataframe.empty:
-            stats_dataframe = pd.DataFrame(stats, index=[0], dtype=np.float32) # First iteration
+            stats_dataframe = pd.DataFrame(stats, index=[0]) # First iteration
         else:
-            stats_dataframe = pd.concat([stats_dataframe, pd.DataFrame(stats, index=[0], dtype=np.float32)], ignore_index=True)
+            stats_dataframe = pd.concat([stats_dataframe, pd.DataFrame(stats, index=[0], ignore_index=True)
 
     if return_index_image is True:
         # Extract the information required to generate the index image
@@ -366,9 +366,9 @@ def load_axon_morphometrics(morphometrics_file):
     try:
         #Use the appropriate loader depending on the extension
         if morphometrics_file.suffix.lower() == ".csv":
-            stats_dataframe = pd.read_csv(morphometrics_file, na_values='NaN', dtype=np.float32)
+            stats_dataframe = pd.read_csv(morphometrics_file, na_values='NaN')
         elif morphometrics_file.suffix.lower() == ".xlsx":
-            stats_dataframe = pd.read_excel(morphometrics_file, na_values='NaN', dtype=np.float32)
+            stats_dataframe = pd.read_excel(morphometrics_file, na_values='NaN')
         else:
             stats_dataframe = pd.read_pickle(morphometrics_file)
     except IOError as e:

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -190,11 +190,10 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                     "centroid [y:{0}, x:{1}]".format(y0, x0)
                     )
         # Add the stats to the dataframe
-        # Question: should we use float32 as a datatype?
         if stats_dataframe.empty:
-            stats_dataframe = pd.DataFrame(stats, index=[0]) # First iteration
+            stats_dataframe = pd.DataFrame(stats, index=[0], dtype=np.float32) # First iteration
         else:
-            stats_dataframe = pd.concat([stats_dataframe, pd.DataFrame(stats, index=[0])], ignore_index=True)
+            stats_dataframe = pd.concat([stats_dataframe, pd.DataFrame(stats, index=[0], dtype=np.float32)], ignore_index=True)
 
     if return_index_image is True:
         # Extract the information required to generate the index image
@@ -367,9 +366,9 @@ def load_axon_morphometrics(morphometrics_file):
     try:
         #Use the appropriate loader depending on the extension
         if morphometrics_file.suffix.lower() == ".csv":
-            stats_dataframe = pd.read_csv(morphometrics_file, na_values='NaN')
+            stats_dataframe = pd.read_csv(morphometrics_file, na_values='NaN', dtype=np.float32)
         elif morphometrics_file.suffix.lower() == ".xlsx":
-            stats_dataframe = pd.read_excel(morphometrics_file, na_values='NaN')
+            stats_dataframe = pd.read_excel(morphometrics_file, na_values='NaN', dtype=np.float32)
         else:
             stats_dataframe = pd.read_pickle(morphometrics_file)
     except IOError as e:

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -63,8 +63,8 @@ def launch_morphometrics_computation(path_img, path_prediction, axon_shape="circ
         path_folder = path_img.parent
 
         # Compute and save axon morphometrics
-        stats_array = get_axon_morphometrics(pred_axon, path_folder, axon_shape=axon_shape)
-        save_axon_morphometrics(path_folder, stats_array)
+        stats_dataframe = get_axon_morphometrics(pred_axon, path_folder, axon_shape=axon_shape)
+        save_axon_morphometrics(path_folder / "morphometrics.pkl", stats_dataframe)
 
         # Generate and save displays of axon morphometrics
         fig = draw_axon_diameter(img, path_prediction, pred_axon, pred_myelin, axon_shape=axon_shape)

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -166,8 +166,6 @@ def main(argv=None):
                         )
                     sys.exit(3)
 
-            x = params.column_names  ## TODO: Find out how to keep units
-
             # Compute statistics
 
             stats_dataframe, index_image_array = get_axon_morphometrics(im_axon=pred_axon, im_myelin=pred_myelin, pixel_size=psm, axon_shape=axon_shape, return_index_image=True)
@@ -178,12 +176,7 @@ def main(argv=None):
             if not (morph_filename.lower().endswith((".xlsx", ".csv"))):  # If the user didn't add the extension, add it here
                 morph_filename = morph_filename + '.xlsx'
             try:
-                # Export to excel
-                if morph_filename.endswith('.xlsx'):
-                    stats_dataframe.to_excel(current_path_target.parent / morph_filename, na_rep='NaN')
-                # Export to csv
-                else:
-                    stats_dataframe.to_csv(current_path_target.parent / morph_filename, na_rep='NaN')
+                save_axon_morphometrics(current_path_target.parent / morph_filename, stats_dataframe)
 
                 # Generate the index image
                 if str(current_path_target) == str(current_path_target.parts[-1]):
@@ -202,7 +195,7 @@ def main(argv=None):
 
                 print(f"Morphometrics file: {morph_filename} has been saved in the {str(current_path_target.parent.absolute())} directory")
             except IOError:
-                print(f"Cannot save morphometrics data or associated index images for file {morph_filename}.")
+                print(f"Cannot save morphometrics data or associated index images for file {current_path_target.parent / morph_filename}.")
 
         else:
             print("The path(s) specified is/are not image(s). Please update the input path(s) and try again.")

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -166,32 +166,11 @@ def main(argv=None):
                         )
                     sys.exit(3)
 
-            x = params.column_names
+            x = params.column_names  ## TODO: Find out how to keep units
 
             # Compute statistics
 
-            stats_array, index_image_array = get_axon_morphometrics(im_axon=pred_axon, im_myelin=pred_myelin, pixel_size=psm, axon_shape=axon_shape, return_index_image=True)
-
-            for stats in stats_array:
-
-                x = np.append(x, np.array(
-                        [(
-                            stats['x0'],
-                            stats['y0'],
-                            stats['gratio'],
-                            stats['axon_area'],
-                            stats['axon_perimeter'],
-                            stats['myelin_area'],
-                            stats['axon_diam'],
-                            stats['myelin_thickness'],
-                            stats['axonmyelin_area'],
-                            stats['axonmyelin_perimeter'],
-                            stats['solidity'],
-                            stats['eccentricity'],
-                            stats['orientation']
-                        )],
-                        dtype=x.dtype)
-                    )
+            stats_dataframe, index_image_array = get_axon_morphometrics(im_axon=pred_axon, im_myelin=pred_myelin, pixel_size=psm, axon_shape=axon_shape, return_index_image=True)
 
             morph_filename = current_path_target.stem + "_" + filename
 
@@ -201,10 +180,10 @@ def main(argv=None):
             try:
                 # Export to excel
                 if morph_filename.endswith('.xlsx'):
-                    pd.DataFrame(x).to_excel(current_path_target.parent / morph_filename, na_rep='NaN')
-                # Export to csv    
-                else: 
-                    pd.DataFrame(x).to_csv(current_path_target.parent / morph_filename, na_rep='NaN')
+                    stats_dataframe.to_excel(current_path_target.parent / morph_filename, na_rep='NaN')
+                # Export to csv
+                else:
+                    stats_dataframe.to_csv(current_path_target.parent / morph_filename, na_rep='NaN')
 
                 # Generate the index image
                 if str(current_path_target) == str(current_path_target.parts[-1]):

--- a/AxonDeepSeg/params.py
+++ b/AxonDeepSeg/params.py
@@ -7,22 +7,32 @@ intensity = {
     'background': np.iinfo(np.uint8).min
 }
 
-# morphometrics column names
-column_names = np.array(
-    [],
-    dtype=[
-        ('x0 (px)', 'f4'),
-        ('y0 (px)', 'f4'),
-        ('gratio', 'f4'),
-        ('axon_area (um\u00b2)', 'f4'), # unicode for ^2
-        ('axon_perimeter (um)', 'f4'),
-        ('myelin_area (um\u00b2)', 'f4'),
-        ('axon_diam (um)', 'f4'),
-        ('myelin_thickness (um)', 'f4'),
-        ('axonmyelin_area (um\u00b2)', 'f4'),
-        ('axonmyelin_perimeter (um)', 'f4'),
-        ('solidity', 'f4'),
-        ('eccentricity', 'f4'),
-        ('orientation', 'f4'),
-    ]
-)
+
+class Morphometrics_Column_Name:
+    """
+    A Morphometrics_Column_Name indicates the key_name and display_name of a morphometrics dataframe column
+    :param key_name: The column name used in the dataframe variable
+    :type key_name: str
+    :param display_name: (optional) The column name that will be displayed in the csv/excel file. This is useful if you
+    want to specify units to the user
+    :type display_name: str
+    """
+    def __init__(self, key_name, display_name=None):
+        self.key_name = key_name
+        self.display_name = display_name
+
+
+# If you want a morphometrics column to have a particular order or a display name with units (or both), you need to add
+# it to this list. Otherwise, the column will be placed at the end of the morphometrics file
+column_names_ordered = [
+    Morphometrics_Column_Name('x0', 'x0 (px)'),
+    Morphometrics_Column_Name('y0', 'y0 (px)'),
+    Morphometrics_Column_Name('gratio'),
+    Morphometrics_Column_Name('axon_area','axon_area (um\u00b2)'), # unicode for ^2
+    Morphometrics_Column_Name('axon_perimeter','axon_perimeter (um)'),
+    Morphometrics_Column_Name('myelin_area', 'myelin_area (um\u00b2)'),
+    Morphometrics_Column_Name('axon_diam','axon_diam (um)'),
+    Morphometrics_Column_Name('myelin_thickness','myelin_thickness (um)'),
+    Morphometrics_Column_Name('axonmyelin_area','axonmyelin_area (um\u00b2)'),
+    Morphometrics_Column_Name('axonmyelin_perimeter','axonmyelin_perimeter (um)'),
+]

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -663,31 +663,10 @@ class ADScontrol(ctrlpanel.ControlPanel):
         x = params.column_names
 
         # Compute statistics
-        stats_array, index_image_array = compute_morphs.get_axon_morphometrics(im_axon=pred_axon, im_myelin=pred_myelin,
+        stats_dataframe, index_image_array = compute_morphs.get_axon_morphometrics(im_axon=pred_axon, im_myelin=pred_myelin,
                                                                                pixel_size=pixel_size,
                                                                                axon_shape=self.settings.axon_shape,
                                                                                return_index_image=True)
-        for stats in stats_array:
-
-            x = np.append(x,
-                np.array(
-                    [(
-                        stats['x0'],
-                        stats['y0'],
-                        stats['gratio'],
-                        stats['axon_area'],
-                        stats['axon_perimeter'],
-                        stats['myelin_area'],
-                        stats['axon_diam'],
-                        stats['myelin_thickness'],
-                        stats['axonmyelin_area'],
-                        stats['axonmyelin_perimeter'],
-                        stats['solidity'],
-                        stats['eccentricity'],
-                        stats['orientation']
-                    )],
-                    dtype=x.dtype)
-                )
 
         with wx.FileDialog(self, "Save morphometrics file", wildcard="Excel files (*.xlsx)|*.xlsx",
                         defaultFile="axon_morphometrics.xlsx", style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT) as fileDialog:
@@ -701,7 +680,7 @@ class ADScontrol(ctrlpanel.ControlPanel):
                 pathname = pathname + ".xlsx"
             try:
                 # Export to excel
-                pd.DataFrame(x).to_excel(pathname, na_rep='NaN')
+                stats_dataframe.to_excel(pathname, na_rep='NaN')
 
             except IOError:
                 wx.LogError("Cannot save current data in file '%s'." % pathname)

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -660,8 +660,6 @@ class ADScontrol(ctrlpanel.ControlPanel):
         pred_axon = pred > 200
         pred_myelin = np.logical_and(pred >= 50, pred <= 200)
 
-        x = params.column_names
-
         # Compute statistics
         stats_dataframe, index_image_array = compute_morphs.get_axon_morphometrics(im_axon=pred_axon, im_myelin=pred_myelin,
                                                                                pixel_size=pixel_size,
@@ -679,8 +677,7 @@ class ADScontrol(ctrlpanel.ControlPanel):
             if not (pathname.lower().endswith((".xlsx", ".csv"))):  # If the user didn't add the extension, add it here
                 pathname = pathname + ".xlsx"
             try:
-                # Export to excel
-                stats_dataframe.to_excel(pathname, na_rep='NaN')
+                compute_morphs.save_axon_morphometrics(pathname, stats_dataframe)
 
             except IOError:
                 wx.LogError("Cannot save current data in file '%s'." % pathname)

--- a/notebooks/02-morphometrics_extraction.ipynb
+++ b/notebooks/02-morphometrics_extraction.ipynb
@@ -58,8 +58,8 @@
    "source": [
     "# Change the image and segmentation paths here for your sample:\n",
     "ads_path = Path(os.path.abspath('')).resolve().parent\n",
-    "path_img = Path(os.path.join(ads_path,'AxonDeepSeg','models','model_seg_rat_axon-myelin_sem','data_test')) / 'image.png'\n",
-    "path_pred = Path(os.path.join(ads_path,'AxonDeepSeg','models','model_seg_rat_axon-myelin_sem','data_test')) / os.path.join('image' + str(axonmyelin_suffix))"
+    "path_img = Path(ads_path)/'AxonDeepSeg'/'models'/'model_seg_rat_axon-myelin_sem'/'data_test'/'image.png'\n",
+    "path_pred = Path(ads_path)/'AxonDeepSeg'/'models'/'model_seg_rat_axon-myelin_sem'/'data_test'/('image' + str(axonmyelin_suffix))"
    ]
   },
   {
@@ -73,7 +73,8 @@
     "pred = ads.imread(path_pred)\n",
     "pred_axon = pred > 200\n",
     "pred_myelin = np.logical_and(pred >= 50, pred <= 200)\n",
-    "path_folder, file_name = os.path.split(path_img)"
+    "path_folder = path_img.parent\n",
+    "file_name = path_img.parts[-1]"
    ]
   },
   {
@@ -106,7 +107,7 @@
     "                        '''       \n",
     "\n",
     "# Computes axon morphometrics\n",
-    "stats_array = get_axon_morphometrics(pred_axon,path_folder, axon_shape=axon_shape)\n"
+    "stats_dataframe = get_axon_morphometrics(pred_axon,path_folder, axon_shape=axon_shape)\n"
    ]
   },
   {
@@ -122,8 +123,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "save_axon_morphometrics(path_folder,stats_array)\n",
-    "stats_array = load_axon_morphometrics(path_folder)"
+    "morphometrics_file = path_folder / \"morphometrics_file.pkl\"\n",
+    "save_axon_morphometrics(morphometrics_file, stats_dataframe)\n",
+    "stats_dataframe = load_axon_morphometrics(morphometrics_file)"
    ]
   },
   {
@@ -140,7 +142,7 @@
    "outputs": [],
    "source": [
     "# Get axon diameter distribution\n",
-    "axon_diam_list = [d['axon_diam'] for d in stats_array]"
+    "axon_diam_list = stats_dataframe[\"axon_diam\"]"
    ]
   },
   {
@@ -172,9 +174,9 @@
    "outputs": [],
    "source": [
     "# Get axon solidity distribution (measure of compactness of the axon)\n",
-    "axon_solidity_list = [d['solidity'] for d in stats_array]\n",
+    "axon_solidity_series = stats_dataframe['solidity']\n",
     "# Get axon eccentricity distribution (measure of ellipticity/extent of the axon)\n",
-    "axon_eccentricity_list = [d['eccentricity'] for d in stats_array]"
+    "axon_eccentricity_series = stats_dataframe['eccentricity']"
    ]
   },
   {
@@ -185,7 +187,7 @@
    "source": [
     "# Plot boxplots of solidity and eccentricity\n",
     "plt.figure(figsize=(6,6))\n",
-    "data_to_plot = [axon_solidity_list,axon_eccentricity_list]\n",
+    "data_to_plot = [axon_solidity_series, axon_eccentricity_series]\n",
     "plt.boxplot(data_to_plot,patch_artist=True)\n",
     "plt.title('Solidity and eccentricity distributions of axons',fontsize=11)\n",
     "plt.grid(True)\n",
@@ -260,7 +262,7 @@
    "outputs": [],
    "source": [
     "# Show metrics available for axons\n",
-    "print(stats_array[0].keys())"
+    "print(stats_dataframe.columns.to_list())"
    ]
   },
   {
@@ -270,7 +272,7 @@
    "outputs": [],
    "source": [
     "# Get axon diameter value of axon object 0\n",
-    "print(stats_array[0]['axon_diam'])"
+    "print(stats_dataframe['axon_diam'][0])"
    ]
   },
   {
@@ -280,7 +282,7 @@
    "outputs": [],
    "source": [
     "# Get solidity value of axon object 50\n",
-    "print(stats_array[49]['solidity'])"
+    "print(stats_dataframe['solidity'][49])"
    ]
   },
   {
@@ -290,7 +292,7 @@
    "outputs": [],
    "source": [
     "# Display all stats for axon object 10\n",
-    "print(stats_array[9])"
+    "print(stats_dataframe.iloc[9])"
    ]
   },
   {
@@ -300,7 +302,7 @@
    "outputs": [],
    "source": [
     "# Get axon diameter value of all axons in list\n",
-    "axon_diam_list = [d['axon_diam'] for d in stats_array]"
+    "axon_diam_list = stats_dataframe['axon_diam']"
    ]
   },
   {
@@ -334,13 +336,6 @@
     "max_diam = np.max(axon_diam_list)\n",
     "print(max_diam)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -360,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -713,7 +713,7 @@ class TestCore(object):
         for column in reference_stats_dataframe:
             column_ref_vals = reference_stats_dataframe[column].to_numpy()
             column_new_vals = new_stats_dataframe[column].to_numpy()
-            assert np.allclose(column_ref_vals, column_new_vals, rtol=0.003, equal_nan=True)
+            assert np.allclose(column_ref_vals, column_new_vals, rtol=0, atol=1e-11, equal_nan=True)
 
 
     # --------------draw_axon_diameter tests-------------- #

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -6,6 +6,7 @@ import random
 import math
 import shutil
 import numpy as np
+import pandas as pd
 from AxonDeepSeg import ads_utils as ads
 import pytest
 
@@ -133,69 +134,63 @@ class TestCore(object):
     # --------------get_axon_morphometrics tests-------------- #
     @pytest.mark.unit
     def test_get_axon_morphometrics_returns_expected_type(self):
-        stats_array = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path))
-        assert isinstance(stats_array, np.ndarray)
+        stats_dataframe = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path))
+        assert isinstance(stats_dataframe, pd.DataFrame)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_returns_expected_type_with_axon_as_ellipse(self):
-        stats_array = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path), axon_shape=self.axon_shape)
-        assert isinstance(stats_array, np.ndarray)
+        stats_dataframe = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path), axon_shape=self.axon_shape)
+        assert isinstance(stats_dataframe, pd.DataFrame)
 
     @pytest.mark.unit
-    def test_get_axon_morphometrics_returns_expected_keys(self):
-        expectedKeys = {'y0',
-                        'x0',
-                        'axon_diam',
-                        'axon_area',
-                        'axon_perimeter',
-                        'axonmyelin_perimeter',
-                        'solidity',
-                        'eccentricity',
-                        'orientation',
-                        'gratio',
-                        'myelin_thickness',
-                        'myelin_area',
-                        'axonmyelin_area',
-                        'axonmyelin_perimeter'
-                        }
+    def test_get_axon_morphometrics_returns_expected_columns(self):
+        expected_columns = {'y0',
+                            'x0',
+                            'axon_diam',
+                            'axon_area',
+                            'axon_perimeter',
+                            'axonmyelin_perimeter',
+                            'solidity',
+                            'eccentricity',
+                            'orientation'
+                           }
 
-        stats_array = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path))
+        stats_dataframe = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path))
 
-        for key in list(stats_array[0].keys()):
-            assert key in expectedKeys
+        for column in stats_dataframe.columns:
+            assert column in expected_columns
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask(self):
-        stats_array = get_axon_morphometrics(
+        stats_dataframe = get_axon_morphometrics(
             self.pred_axon,
             str(self.test_folder_path),
             im_myelin=self.pred_myelin
             )
-        print("The values are ", stats_array[1]['gratio'], stats_array[1]['axon_diam'], stats_array[1]['myelin_thickness'])
-        assert stats_array[1]['gratio'] == pytest.approx(0.74, rel=0.01)
+        print("The values are ", stats_dataframe['gratio'][1], stats_dataframe['axon_diam'][1], stats_dataframe['myelin_thickness'][1])
+        assert stats_dataframe['gratio'][1] == pytest.approx(0.74, rel=0.01)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask_with_axon_as_ellipse(self):
-        stats_array = get_axon_morphometrics(
+        stats_dataframe = get_axon_morphometrics(
             self.pred_axon,
             str(self.test_folder_path),
             im_myelin=self.pred_myelin,
             axon_shape=self.axon_shape
             )
-        print("The values are ", stats_array[1]['gratio'], stats_array[1]['axon_diam'], stats_array[1]['myelin_thickness'])
+        print("The values are ", stats_dataframe['gratio'][1], stats_dataframe['axon_diam'][1], stats_dataframe['myelin_thickness'][1])
 
-        assert stats_array[1]['gratio'] == pytest.approx(0.78, rel=0.01)
+        assert stats_dataframe['gratio'][1] == pytest.approx(0.78, rel=0.01)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_invalid_gratio_with_axon_as_ellipse(self):
-        stats_array = get_axon_morphometrics(
+        stats_dataframe = get_axon_morphometrics(
             self.bad_pred_axon,
             str(self.test_folder_path),
             im_myelin=self.bad_pred_myelin,
             axon_shape=self.axon_shape
             )
-
-        assert np.isnan(stats_array[0]['gratio'])
+        assert np.isnan(stats_dataframe['gratio'][0])
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask_simulated_axons(self):
@@ -238,12 +233,12 @@ class TestCore(object):
         pred_myelin = np.logical_and(pred >= 50, pred <= 200)
 
         # compute axon morphometrics
-        stats_array = get_axon_morphometrics(pred_axon, str(path_pred.parent), im_myelin=pred_myelin)
+        stats_dataframe = get_axon_morphometrics(pred_axon, str(path_pred.parent), im_myelin=pred_myelin)
 
         for ii in range(0, len(gratio_sim)):
-            assert stats_array[ii]['gratio'] == pytest.approx(gratio_sim[ii], rel=0.1)
-            assert stats_array[ii]['axon_diam'] == pytest.approx(axon_diam_sim[ii], rel=0.1)
-            assert stats_array[ii]['myelin_thickness'] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
+            assert stats_dataframe['gratio'][ii] == pytest.approx(gratio_sim[ii], rel=0.1)
+            assert stats_dataframe['axon_diam'][ii] == pytest.approx(axon_diam_sim[ii], rel=0.1)
+            assert stats_dataframe['myelin_thickness'][ii] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask_simulated_axons_with_axon_as_ellipse_all_argument_varies(self):
@@ -293,12 +288,12 @@ class TestCore(object):
         pred_myelin = np.logical_and(pred >= 50, pred <= 200)
 
         # compute axon morphometrics
-        stats_array = get_axon_morphometrics(pred_axon, str(self.image_sim_ellipse_path.parent), im_myelin=pred_myelin, axon_shape=self.axon_shape)
+        stats_dataframe = get_axon_morphometrics(pred_axon, str(self.image_sim_ellipse_path.parent), im_myelin=pred_myelin, axon_shape=self.axon_shape)
 
         for ii in range(0, len(gratio_sim)):
-            assert stats_array[ii]['gratio'] == pytest.approx(gratio_sim[ii], rel=0.1)
-            assert stats_array[ii]['axon_diam'] == pytest.approx(axon_diam_sim[ii], rel=0.1)
-            assert stats_array[ii]['myelin_thickness'] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
+            assert stats_dataframe['gratio'][ii] == pytest.approx(gratio_sim[ii], rel=0.1)
+            assert stats_dataframe['axon_diam'][ii] == pytest.approx(axon_diam_sim[ii], rel=0.1)
+            assert stats_dataframe['myelin_thickness'][ii] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask_simulated_axons_with_axon_as_ellipse_gratio_varies(self):
@@ -339,13 +334,13 @@ class TestCore(object):
         pred_myelin = np.logical_and(pred >= 50, pred <= 200)
 
         # compute axon morphometrics
-        stats_array = get_axon_morphometrics(pred_axon, str(self.image_sim_ellipse_path.parent), im_myelin=pred_myelin, axon_shape=self.axon_shape)
+        stats_dataframe = get_axon_morphometrics(pred_axon, str(self.image_sim_ellipse_path.parent), im_myelin=pred_myelin, axon_shape=self.axon_shape)
 
         for ii in range(0, len(gratio_sim)):
 
-            assert stats_array[ii]['gratio'] == pytest.approx(gratio_sim[ii], rel=0.1)
-            assert stats_array[ii]['axon_diam'] == pytest.approx(axon_diam_sim[ii], rel=0.1)
-            assert stats_array[ii]['myelin_thickness'] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
+            assert stats_dataframe['gratio'][ii] == pytest.approx(gratio_sim[ii], rel=0.1)
+            assert stats_dataframe['axon_diam'][ii] == pytest.approx(axon_diam_sim[ii], rel=0.1)
+            assert stats_dataframe['myelin_thickness'][ii] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask_simulated_axons_with_axon_as_ellipse_plane_angle_varies(self):
@@ -394,12 +389,12 @@ class TestCore(object):
         pred_myelin = np.logical_and(pred >= 50, pred <= 200)
 
         # compute axon morphometrics
-        stats_array = get_axon_morphometrics(pred_axon, str(self.image_sim_ellipse_path.parent), im_myelin=pred_myelin, axon_shape=self.axon_shape)
+        stats_dataframe = get_axon_morphometrics(pred_axon, str(self.image_sim_ellipse_path.parent), im_myelin=pred_myelin, axon_shape=self.axon_shape)
 
         for ii in range(0, len(gratio_sim)):
-            assert stats_array[ii]['gratio'] == pytest.approx(gratio_sim[ii], rel=0.1)
-            assert stats_array[ii]['axon_diam'] == pytest.approx(axon_diam_sim[ii], rel=0.1)
-            assert stats_array[ii]['myelin_thickness'] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
+            assert stats_dataframe['gratio'][ii] == pytest.approx(gratio_sim[ii], rel=0.1)
+            assert stats_dataframe['axon_diam'][ii] == pytest.approx(axon_diam_sim[ii], rel=0.1)
+            assert stats_dataframe['myelin_thickness'][ii] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_myelin_mask_simulated_axons_with_axon_as_ellipse_radius_varies(self):
@@ -451,12 +446,12 @@ class TestCore(object):
         pred_myelin = np.logical_and(pred >= 50, pred <= 200)
 
         # Compute axon morphometrics
-        stats_array = get_axon_morphometrics(pred_axon, str(self.image_sim_ellipse_path.parent), im_myelin=pred_myelin, axon_shape=self.axon_shape)
+        stats_dataframe = get_axon_morphometrics(pred_axon, str(self.image_sim_ellipse_path.parent), im_myelin=pred_myelin, axon_shape=self.axon_shape)
 
         for ii in range(0, len(gratio_sim)):
-            assert stats_array[ii]['gratio'] == pytest.approx(gratio_sim[ii], rel=0.1)
-            assert stats_array[ii]['axon_diam'] == pytest.approx(axon_diam_sim[ii], rel=0.1)
-            assert stats_array[ii]['myelin_thickness'] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
+            assert stats_dataframe['gratio'][ii] == pytest.approx(gratio_sim[ii], rel=0.1)
+            assert stats_dataframe['axon_diam'][ii] == pytest.approx(axon_diam_sim[ii], rel=0.1)
+            assert stats_dataframe['myelin_thickness'][ii] == pytest.approx(myelin_thickness_sim[ii], rel=0.1)
 
     @pytest.mark.unit
     def test_get_axon_morphometrics_with_unexpected_myelin_mask_simulated_axons(self):
@@ -471,13 +466,13 @@ class TestCore(object):
         pred_axon = pred > 200
         unexpected_pred_myelin = np.zeros(pred.shape)
 
-        stats_array = get_axon_morphometrics(
+        stats_dataframe = get_axon_morphometrics(
             pred_axon,
             str(path_pred.parent),
             im_myelin=unexpected_pred_myelin
             )
 
-        for axon_prop in stats_array:
+        for axon_index, axon_prop in stats_dataframe.iterrows():
             assert axon_prop['myelin_thickness'] == pytest.approx(0.0, rel=0.01)
             assert axon_prop['myelin_area'] == pytest.approx(0.0, rel=0.01)
             assert axon_prop['gratio'] == pytest.approx(1.0, rel=0.01)
@@ -488,14 +483,14 @@ class TestCore(object):
         pred_axon = pred > 200
         unexpected_pred_myelin = np.zeros(pred.shape)
 
-        stats_array = get_axon_morphometrics(
+        stats_dataframe = get_axon_morphometrics(
             pred_axon,
             str(self.image_sim_ellipse_path.parent),
             im_myelin=unexpected_pred_myelin,
             axon_shape=self.axon_shape
             )
 
-        for axon_prop in stats_array:
+        for axon_index, axon_prop in stats_dataframe.iterrows():
             assert axon_prop['myelin_thickness'] == pytest.approx(0.0, rel=0.01)
             assert axon_prop['myelin_area'] == pytest.approx(0.0, rel=0.01)
             assert axon_prop['gratio'] == pytest.approx(1.0, rel=0.01)
@@ -531,14 +526,14 @@ class TestCore(object):
         pred_axon = pred > 200
         pred_myelin = np.logical_and(pred >= 50, pred <= 200)
 
-        stats_array = get_axon_morphometrics(
+        stats_dataframe = get_axon_morphometrics(
             pred_axon,
             str(image_sim_path.parent),
             im_myelin=pred_myelin
             )
 
         for ii in range(0, len(axon_diam_sim)):
-            assert stats_array[ii]['axon_perimeter'] == pytest.approx(axon_perimeter_sim[ii], rel=0.1)
+            assert stats_dataframe['axon_perimeter'][ii] == pytest.approx(axon_perimeter_sim[ii], rel=0.1)
 
         if image_sim_path.exists():
             image_sim_path.unlink()
@@ -603,14 +598,14 @@ class TestCore(object):
         pred_axon = pred > 200
         pred_myelin = np.logical_and(pred >= 50, pred <= 200)
 
-        stats_array = get_axon_morphometrics(
+        stats_dataframe = get_axon_morphometrics(
             pred_axon,
             str(image_sim_path.parent),
             im_myelin=pred_myelin
             )
 
         for ii in range(0, len(gratio_sim)):
-            assert stats_array[ii]['axonmyelin_perimeter'] == pytest.approx(axonmyelin_perimeter_sim[ii], rel=0.1)
+            assert stats_dataframe['axonmyelin_perimeter'][ii] == pytest.approx(axonmyelin_perimeter_sim[ii], rel=0.1)
 
         if image_sim_path.exists():
             image_sim_path.unlink()
@@ -618,49 +613,44 @@ class TestCore(object):
     # --------------save and load _axon_morphometrics tests-------------- #
     @pytest.mark.unit
     def test_save_axon_morphometrics_creates_file_in_expected_location(self):
-        stats_array = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path))
-
-        save_axon_morphometrics(str(self.tmpDir), stats_array)
-
-        # Filename 'axonlist.npy' is hardcoded in `save_axon_morphometrics()`.
-        expectedFilePath = self.tmpDir / 'axonlist.npy'
-
+        stats_dataframe = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path))
+        save_axon_morphometrics(str(self.tmpDir / 'morphometrics.pkl'), stats_dataframe)
+        expectedFilePath = self.tmpDir / 'morphometrics.pkl'
         assert expectedFilePath.is_file()
 
     @pytest.mark.unit
     def test_save_axon_morphometrics_throws_error_if_folder_doesnt_exist(self):
-        stats_array = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path))
+        stats_dataframe = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path))
 
         nonExistingFolder = ''.join(random.choice(string.ascii_lowercase) for i in range(16))
         nonExistingFolder = Path(nonExistingFolder)
 
         with pytest.raises(IOError):
-            save_axon_morphometrics(str(nonExistingFolder), stats_array)
+            save_axon_morphometrics(str(nonExistingFolder / "morphometrics.pkl"), stats_dataframe)
 
     @pytest.mark.unit
     def test_load_axon_morphometrics_returns_identical_var_as_was_saved(self):
-        original_stats_array = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path), im_myelin=self.pred_myelin)
+        original_stats_dataframe = get_axon_morphometrics(self.pred_axon, str(self.test_folder_path), im_myelin=self.pred_myelin)
+        morphometrics_file_path = self.tmpDir / "morphometrics.pkl"
 
-        save_axon_morphometrics(str(self.tmpDir), original_stats_array)
+        save_axon_morphometrics(morphometrics_file_path, original_stats_dataframe)
 
-        # Load method only takes in a directory as an argument, expects that
-        # 'axonlist.npy' will be in directory.
-        loaded_stats_array = load_axon_morphometrics(str(self.tmpDir))
+        # Load method only takes in a file path as an argument and returns the loaded dataframe
+        loaded_stats_dataframe = load_axon_morphometrics(morphometrics_file_path)
 
-        # Because of the occasional presence in NaNs, which can't be compared well in our lists of dicts,
-        # loop through each row and skip the axons that are not well behaving.
-        for row_original, row_loaded in zip(original_stats_array, loaded_stats_array):
-            if any(math.isnan(val) for val in row_original.values()) == False and any(math.isnan(val) for val in row_loaded.values()) == False:
-                assert np.array_equal(row_loaded, row_original)
+        # Reorder the loaded dataframe so that the column order matches
+        loaded_stats_dataframe = loaded_stats_dataframe[original_stats_dataframe.columns]
+
+        assert original_stats_dataframe.equals(loaded_stats_dataframe)
 
     @pytest.mark.unit
-    def test_load_axon_morphometrics_throws_error_if_folder_doesnt_exist(self):
+    def test_load_axon_morphometrics_throws_error_if_file_doesnt_exist(self):
 
         nonExistingFolder = ''.join(random.choice(string.ascii_lowercase) for i in range(16))
         nonExistingFolder = Path(nonExistingFolder)
 
-        with pytest.raises(IOError):
-            load_axon_morphometrics(str(nonExistingFolder))
+        with pytest.raises(FileNotFoundError):
+            load_axon_morphometrics(nonExistingFolder / "dummy_name.pkl")
 
     # --------------check consistency with reference morphometrics-------------- #
     @pytest.mark.unit
@@ -801,3 +791,8 @@ class TestCore(object):
 
         with pytest.raises(IOError):
             write_aggregate_morphometrics(str(nonExistingFolder), aggregate_metrics)
+
+
+if __name__ == '__main__':
+    T = TestCore()
+    T.setup()

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -713,7 +713,7 @@ class TestCore(object):
         for column in reference_stats_dataframe:
             column_ref_vals = reference_stats_dataframe[column].to_numpy()
             column_new_vals = new_stats_dataframe[column].to_numpy()
-            assert np.allclose(column_ref_vals, column_new_vals, rtol=0, atol=1e-11, equal_nan=True)
+            assert np.allclose(column_ref_vals, column_new_vals, rtol=0.003, equal_nan=True)
 
 
     # --------------draw_axon_diameter tests-------------- #

--- a/test/morphometrics/test_launch_morphometrics_computation.py
+++ b/test/morphometrics/test_launch_morphometrics_computation.py
@@ -36,7 +36,7 @@ class TestCore(object):
     def test_launch_morphometrics_computation_saves_expected_files(self):
         expectedFiles = {'aggregate_morphometrics.txt',
                          'AxonDeepSeg_map-axondiameter.png',
-                         'axonlist.npy'
+                         'morphometrics.pkl'
                          }
 
         pathImg = self.dataPath / 'image.png'
@@ -53,7 +53,7 @@ class TestCore(object):
     def test_launch_morphometrics_computation_saves_expected_files_with_axon_as_ellipse(self):
         expectedFiles = {'aggregate_morphometrics.txt',
                          'AxonDeepSeg_map-axondiameter.png',
-                         'axonlist.npy'
+                         'morphometrics.pkl'
                          }
 
         pathImg = self.dataPath / 'image.png'


### PR DESCRIPTION
## Checklist

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [X] I've added relevant tests for my contribution
- [X] I've updated the documentation and/or added correct docstrings
- [X] I've assigned a reviewer
- [X] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
The goal of this PR is to simplify the code around the data structures used for manipulating the results of the morphometrics computation.
As stated in #540, the current way we use data structures to store the morphometrics results can be confusing are requires to restructure a numpy array whenever we want to save the morphometrics. The current saving process actually consists of converting the restructured numpy array into a pandas.DataFrame in order to save it. So why not use a right pandasDataFrame from the start?
This modifies a good portion of the tests since the many of them use the numpy array of dictionnaries.

Bonus: This also provides a method to read csv and excel files (we previously could only read saved numpy arrays).

## Linked issues
Resolves #540 