### PR TITLE
Add border_touching flag to morphometrics

### DIFF
--- a/AxonDeepSeg/download_tests.py
+++ b/AxonDeepSeg/download_tests.py
@@ -10,7 +10,7 @@ def download_tests(destination=None):
         destination = convert_path(destination)
         test_files_destination = destination / "__test_files__"
 
-    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20220607a.zip"  
+    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20220522a.zip"  
     files_before = list(Path.cwd().iterdir())
 
     if (

--- a/AxonDeepSeg/download_tests.py
+++ b/AxonDeepSeg/download_tests.py
@@ -10,7 +10,7 @@ def download_tests(destination=None):
         destination = convert_path(destination)
         test_files_destination = destination / "__test_files__"
 
-    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20220522a.zip"  
+    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20220607a.zip"  
     files_before = list(Path.cwd().iterdir())
 
     if (

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -77,6 +77,8 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
     # Measure properties for each axon object
     axon_objects = measure.regionprops(im_axon_label)
 
+    im_shape = im_axon.shape
+
     # Deal with myelin mask
     if im_myelin is not None:
 
@@ -150,7 +152,8 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                 'myelin_thickness': np.nan,
                 'myelin_area': np.nan,
                 'axonmyelin_area': np.nan,
-                'axonmyelin_perimeter': np.nan
+                'axonmyelin_perimeter': np.nan,
+                'border_touching': False
             }
             stats.update(myelin_stats)
             # Find label of axonmyelin corresponding to axon centroid
@@ -183,6 +186,11 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                     stats['myelin_area'] = np.nan
                     stats['axonmyelin_area'] = np.nan
                     stats['axonmyelin_perimeter'] = np.nan
+
+                # check if bounding box touches a border (partial axonmyelin object)
+                bbox = prop_axonmyelin.bbox
+                if 0 in bbox[:2] or bbox[2] == im_shape[0] or bbox[3] == im_shape[1]:
+                    stats['border_touching'] = True
 
             else:
                 print(

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -152,7 +152,7 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                 'myelin_area': np.nan,
                 'axonmyelin_area': np.nan,
                 'axonmyelin_perimeter': np.nan,
-                'border_touching': False
+                'image_border_touching': False
             }
             stats.update(myelin_stats)
             # Find label of axonmyelin corresponding to axon centroid
@@ -189,7 +189,7 @@ def get_axon_morphometrics(im_axon, path_folder=None, im_myelin=None, pixel_size
                 # check if bounding box touches a border (partial axonmyelin object)
                 bbox = prop_axonmyelin.bbox
                 if 0 in bbox[:2] or bbox[2] == im_shape[0] or bbox[3] == im_shape[1]:
-                    stats['border_touching'] = True
+                    stats['image_border_touching'] = True
 
             else:
                 logger.warning(f"WARNING: Myelin object not found for axon centroid [y:{y0}, x:{x0}]")

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -514,7 +514,7 @@ By default for axon shape, that is, `circle`, the equivalent diameter is used. F
      - Eccentricity of the ellipse that has the same second-moments as the axon region.
    * - orientation
      - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region.
-   * - border_touching
+   * - image_border_touching
      - Flag indicating if the axonmyelin objects touches the image border
 
 Jupyter notebooks

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -510,6 +510,8 @@ By default for axon shape, that is, `circle`, the equivalent diameter is used. F
      - Eccentricity of the ellipse that has the same second-moments as the axon region.
    * - orientation
      - Angle between the 0th axis (rows) and the major axis of the ellipse that has the same second moments as the axon region.
+   * - border_touching
+     - Flag indicating if the axonmyelin objects touches the image border
 
 Jupyter notebooks
 -----------------


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
This PR adds a flag in the morphometrics to tell the user if the axonmyelin object touches a border for faster manual filtering. Thanks to the morph. data structure refactoring, this was very quick to implement.

I tested the PR on the following test image:
![test_img_axonmyelin_index](https://user-images.githubusercontent.com/83031821/171877496-dcc705b9-4d5e-47dd-8f0e-ad6220b16ad7.png)
According to the new `border_touching` column, the elements touching the border are the following:
```
0 1 2 3 4 7 9 12 13
```
As we can see, most of these are unusable except for id=3 where the element touches the border but is still good, so it would still require the user to take a look at the result.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #638 