### PR TITLE
Segment images without patches

### DIFF
--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -21,9 +21,11 @@ def axon_segmentation(
     :param path_acquisitions_folders: the directory containing the images to segment.
     :param acquisitions_filenames: filenames of the images to segment.
     :param path_model_folder: path to the folder of the IVADOMED-trained model.
-    :param overlap_value: the number of pixels to be used for overlap when doing prediction. Higher value means less
-    border effects but more time to perform the segmentation.
+    :param overlap_value: the number of pixels to be used for overlap between patches when doing prediction.
+    Higher value means less border effects but more time to perform the segmentation.
     :param acquired_resolution: isotropic pixel size of the acquired images.
+    :param no_patch: If True, the image is segmented without using patches. Default: False. This parameter supersedes
+    the "overlap_value" parameter. It may not be suitable with large images depending on computer RAM capacity.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.

--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -27,7 +27,7 @@ def axon_segmentation(
     Higher value means less border effects but more time to perform the segmentation.
     :param acquired_resolution: isotropic pixel size of the acquired images.
     :param no_patch: If True, the image is segmented without using patches. Default: False. This parameter supersedes
-    the "overlap_value" parameter. It may not be suitable with large images depending on computer RAM capacity.
+    the "overlap_value" parameter. This option may not be suitable with large images depending on computer RAM capacity.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.

--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -13,6 +13,7 @@ def axon_segmentation(
                     path_model_folder,
                     acquired_resolution,
                     overlap_value=[48,48],
+                    no_patch=False,
                     verbosity_level = 0
                     ):
     '''
@@ -28,11 +29,13 @@ def axon_segmentation(
     :return: Nothing.
     '''
 
-
-
     path_model=path_model_folder
     input_filenames = acquisitions_filenames
-    options = {"pixel_size": [acquired_resolution, acquired_resolution], "pixel_size_units": "um", "overlap_2D": overlap_value, "binarize_maxpooling": True}
+    options = {"pixel_size": [acquired_resolution, acquired_resolution], "pixel_size_units": "um",
+               "overlap_2D": overlap_value, "binarize_maxpooling": True}
+    #TODO: Deal with overlap_2D when no_patch is True (CLI and default value)
+    if no_patch:
+        options["no_patch"] = no_patch
 
     # IVADOMED automated segmentation
     nii_lst, _ = imed_inference.segment_volume(str(path_model), input_filenames, options=options)

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -127,6 +127,7 @@ def segment_image(
     border effects but more time to perform the segmentation.
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
     :param zoom_factor: multiplicative constant applied to the pixel size before model inference.
+    :param no_patch: If True, the image is segmented without using patches. Default: False.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.
@@ -219,6 +220,7 @@ def segment_folders(path_testing_images_folder, path_model,
     border effects but more time to perform the segmentation.
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
     :param zoom_factor: multiplicative constant applied to the pixel size before model inference.
+    :param no_patch: If True, the image is segmented without using patches. Default: False.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.
@@ -408,9 +410,9 @@ def main(argv=None):
         dest="no_patch",
         action='store_true',
         required=False,
-        help='2D patches are not used while segmenting with models trained with patches '
-             'The "--no-patch" argument supersedes the "--overlap-2D" argument. '
-             'This option may not be suitable with large images depending on computer RAM capacity.'
+        help='When applying the model, the image is segmented without using patches. \n'
+             'The "--no-patch" flag supersedes the "--overlap" flag. \n'
+             'It may not be suitable with large images depending on computer RAM capacity.'
     )
     ap._action_groups.reverse()
 

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -380,7 +380,7 @@ def main(argv=None):
             + 'but also increase the segmentation time. \n'
             + 'Default value: '+str(default_overlap)+'\n'
             + 'Recommended range of values: [10-100]. \n',
-        default=default_overlap,
+        default=None
     )
     ap.add_argument(
         "-z", "--zoom", 
@@ -420,7 +420,7 @@ def main(argv=None):
     args = vars(ap.parse_args(argv))
     type_ = str(args["type"])
     verbosity_level = int(args["verbose"])
-    overlap_value = [int(args["overlap"]), int(args["overlap"])]
+    overlap_value = [int(args["overlap"]), int(args["overlap"])] if args["overlap"] else None
     if args["sizepixel"] is not None:
         psm = float(args["sizepixel"])
     else:

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -114,9 +114,10 @@ def segment_image(
                 path_testing_image,
                 path_model,
                 overlap_value,
-                acquired_resolution = None,
-                zoom_factor = 1.0,
-                verbosity_level = 0):
+                acquired_resolution=None,
+                zoom_factor=1.0,
+                no_patch=False,
+                verbosity_level=0):
 
     '''
     Segment the image located at the path_testing_image location.
@@ -191,7 +192,7 @@ def segment_image(
         axon_segmentation(path_acquisitions_folders=path_acquisition,
                           acquisitions_filenames=[str(path_acquisition / acquisition_name)],
                           path_model_folder=path_model, acquired_resolution=acquired_resolution*zoom_factor,
-                          overlap_value=overlap_value)
+                          overlap_value=overlap_value, no_patch=no_patch)
 
         if verbosity_level >= 1:
             logger.info(f"Image {path_testing_image} segmented.")
@@ -205,8 +206,9 @@ def segment_image(
 @logger.catch
 def segment_folders(path_testing_images_folder, path_model,
                     overlap_value, 
-                    acquired_resolution = None,
-                    zoom_factor = 1.0,
+                    acquired_resolution=None,
+                    zoom_factor=1.0,
+                    no_patch=False,
                     verbosity_level=0):
     '''
     Segments the images contained in the image folders located in the path_testing_images_folder.
@@ -299,7 +301,7 @@ def segment_folders(path_testing_images_folder, path_model,
             axon_segmentation(path_acquisitions_folders=path_testing_images_folder,
                             acquisitions_filenames=[str(path_testing_images_folder  / acquisition_name)],
                             path_model_folder=path_model, acquired_resolution=acquired_resolution*zoom_factor,
-                            overlap_value=overlap_value)
+                            overlap_value=overlap_value, no_patch=no_patch)
             if verbosity_level >= 1:
                 tqdm.write("Image {0} segmented.".format(str(path_testing_images_folder / file_)))
 
@@ -401,6 +403,15 @@ def main(argv=None):
         help='Number of zoom factor values to be computed by the sweep.',
         default=None,
     )
+    ap.add_argument(
+        "--no-patch",
+        dest="no_patch",
+        action='store_true',
+        required=False,
+        help='2D patches are not used while segmenting with models trained with patches '
+             'The "--no-patch" argument supersedes the "--overlap-2D" argument. '
+             'This option may not be suitable with large images depending on computer RAM capacity.'
+    )
     ap._action_groups.reverse()
 
     # Processing the arguments
@@ -418,6 +429,7 @@ def main(argv=None):
         zoom_factor = float(args["zoom"])
     else:
         zoom_factor = 1.0
+    no_patch = bool(args["no_patch"])
 
     # check for sweep mode
     sweep_mode = (args["sweeprange"] is not None) & (args["sweeplength"] is not None)
@@ -464,6 +476,7 @@ def main(argv=None):
                         sweep_range=sweep_range,
                         sweep_length=sweep_length,
                         acquired_resolution=psm,
+                        no_patch=no_patch,
                     )
                 else:
                     segment_image(
@@ -472,6 +485,7 @@ def main(argv=None):
                         overlap_value=overlap_value,
                         acquired_resolution=psm,
                         zoom_factor=zoom_factor,
+                        no_patch=no_patch,
                         verbosity_level=verbosity_level
                     )
 
@@ -507,6 +521,7 @@ def main(argv=None):
                 overlap_value=overlap_value,
                 acquired_resolution=psm,
                 zoom_factor=zoom_factor,
+                no_patch=no_patch,
                 verbosity_level=verbosity_level
                 )
 

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -412,7 +412,7 @@ def main(argv=None):
         required=False,
         help='When applying the model, the image is segmented without using patches. \n'
              'The "--no-patch" flag supersedes the "--overlap" flag. \n'
-             'It may not be suitable with large images depending on computer RAM capacity.'
+             'This option may not be suitable with large images depending on computer RAM capacity.'
     )
     ap._action_groups.reverse()
 

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -410,7 +410,7 @@ def main(argv=None):
         dest="no_patch",
         action='store_true',
         required=False,
-        help='When applying the model, the image is segmented without using patches. \n'
+        help='Flag to segment the image without using patches. \n'
              'The "--no-patch" flag supersedes the "--overlap" flag. \n'
              'This option may not be suitable with large images depending on computer RAM capacity.'
     )

--- a/AxonDeepSeg/zoom_factor_sweep.py
+++ b/AxonDeepSeg/zoom_factor_sweep.py
@@ -37,6 +37,7 @@ def sweep(
     :param sweep_range:         tuple with lower and upper bounds for the zoom factor range
     :param sweep_length:        number of equidistant zoom factor values to sample from the range
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
+    :param no_patch:            If True, the image is segmented without using patches. Default: False.
     :return: Nothing.
     """
 

--- a/AxonDeepSeg/zoom_factor_sweep.py
+++ b/AxonDeepSeg/zoom_factor_sweep.py
@@ -26,6 +26,7 @@ def sweep(
     sweep_range,
     sweep_length,
     acquired_resolution = None,
+    no_patch=False
     ):
     """
     Wrapper over segment_image to produce segmentations for zoom factor values within a given range.
@@ -64,6 +65,7 @@ def sweep(
             overlap_value,
             acquired_resolution,
             zoom_factor,
+            no_patch=no_patch
         )    
         # move and rename segmentations
         for path_seg in path_seg_outputs:

--- a/AxonDeepSeg/zoom_factor_sweep.py
+++ b/AxonDeepSeg/zoom_factor_sweep.py
@@ -61,11 +61,11 @@ def sweep(
             continue
 
         ads_seg.segment_image(
-            path_image,
-            path_model,
-            overlap_value,
-            acquired_resolution,
-            zoom_factor,
+            path_testing_image=path_image,
+            path_model=path_model,
+            overlap_value=overlap_value,
+            acquired_resolution=acquired_resolution,
+            zoom_factor=zoom_factor,
             no_patch=no_patch
         )    
         # move and rename segmentations

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -256,6 +256,10 @@ The script to launch is called **axondeepseg**. It takes several arguments:
 -z ZOOM             Zoom factor.
                     When applying the model, the size of the segmentation patches relative to the image size will change according to this factor.
 
+--no-patch          When applying the model, the image is segmented without using patches.
+                    The "--no-patch" flag supersedes the "--overlap" flag.
+                    This option may not be suitable with large images depending on computer RAM capacity.
+
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:
    ::
 

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -250,14 +250,14 @@ The script to launch is called **axondeepseg**. It takes several arguments:
 
                         **1**: Developer mode. Shows more information on the terminal, useful for debugging.. 
 
---overlap           Overlap value (in pixels) of the patches when doing the segmentation. 
+--overlap OVERLAP   Overlap value (in pixels) of the patches when doing the segmentation.
                     Higher values of overlap can improve the segmentation at patch borders, but also increase the segmentation time. Default value: 48. Recommended range of values: [10-100]. 
 
 -z ZOOM             Zoom factor.
                     When applying the model, the size of the segmentation patches relative to the image size will change according to this factor.
 
---no-patch          When applying the model, the image is segmented without using patches.
-                    The "--no-patch" flag supersedes the "--overlap" flag.
+--no-patch          Flag to segment the image without using patches.
+                    The "no-patch" flag supersedes the "overlap" flag.
                     This option may not be suitable with large images depending on computer RAM capacity.
 
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:
@@ -362,6 +362,7 @@ The script to launch is called **axondeepseg_morphometrics**. It has several arg
 
 -b                  Flag to extract additionnal bounding box information on axonmyelin objects.
                     Specifying this option ``-b`` flag will add a boolean value indicating if the axon touches one of the image border. It will also output every axon's bounding box (including its myelin). For more information, see the morphometrics file description in the subsection below.
+
 -c                  Flag to save the colorized instance segmentation. For more information about this feature, see the *Colorization* subsection below.
 
 Morphometrics of a single image
@@ -391,7 +392,7 @@ This generates a **'77_axon_morphometrics.xlsx'** file in the image directory::
             axondeepseg -i test_segmentation/test_sem_image/image1_sem/77.png -a ellipse
 
 Morphometrics of a specific image from multiple folders
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 To generate morphometrics of images which are located in different folders, specify the path of the image folders using the **-i** argument of the CLI separated by space. For instance, to compute morphometrics of the image **'77.png'** and **'image.png'** present in the folders **'test_sem_image/image1_sem/'** and **'test_sem_image/image2_sem/'** respectively of the test dataset, use the following command::
 
     axondeepseg_morphometrics -i test_segmentation/test_sem_image/image1_sem/77.png test_segmentation/test_sem_image/image2_sem/image.png

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -389,6 +389,22 @@ class TestCore(object):
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 5)
 
     @pytest.mark.integration
+    def test_main_cli_runs_succesfully_with_nopatch_flag(self):
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.37", "--no-patch"])
+
+        assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
+
+    @pytest.mark.integration
+    def test_main_cli_runs_succesfully_with_nopatch_and_overlap_flags(self):
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.37", "--no-patch", "--overlap", "48"])
+
+        assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
+
+    @pytest.mark.integration
     def test_main_cli_creates_logfile(self):
 
         with pytest.raises(SystemExit) as pytest_wrapped_e:


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR adds the option to segment without patches with the `--no-patch` flag in the CLI (as implemented in ivadomed v2.9.7).

The PR is still a draft, TODO:
- [x] Fix default overlap when using the no-patch option [here](https://github.com/axondeepseg/axondeepseg/blob/86a93308842a61175e0e75ddb8aeaae7fb2d6034/AxonDeepSeg/apply_model.py#L36)
- [x] Update documentation
- [x] Update docstrings
- [x] Add test

## Linked issues
Fixes #676 