### PR TITLE
Add GPU ID setting in CLI and FSLeyes

### DIFF
--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 import raven
 import imageio
 import numpy as np
+from loguru import logger
 
 from config import valid_extensions
 
@@ -331,6 +332,26 @@ def get_file_extension(filename):
     # Find the first match from the list of supported file extensions
     extension = next((ext for ext in valid_extensions if str(filename).lower().endswith(ext)), None)
     return extension
+
+def check_available_gpus(gpu_id):
+    """ Get the number of available GPUs
+    Args:
+        gpu_id (int): Number representing the requested GPU ID for segmentation
+    Returns:
+        n_gpus: Number of available GPUs
+    """
+    from torch.cuda import device_count
+    n_gpus = device_count()
+    if (gpu_id is not None) and (gpu_id < 0):
+        logger.error("The GPU ID must be 0 or a positive integer.")
+        sys.exit(3)
+    elif (gpu_id is not None) and n_gpus == 0:
+        logger.warning("No GPU available, using CPU.")
+    elif (gpu_id is not None) and (gpu_id > n_gpus-1):
+        logger.error(f"GPU ID '{str(gpu_id)}' is not available. The available GPU IDs are {str(list(range(n_gpus)))}.")
+        sys.exit(3)
+
+    return n_gpus
 
 # Call init_ads() automatically when module is imported
 # init_ads()

--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -29,7 +29,7 @@ def axon_segmentation(
     :param acquired_resolution: isotropic pixel size of the acquired images.
     :param no_patch: If True, the image is segmented without using patches. Default: False. This parameter supersedes
     the "overlap_value" parameter. This option may not be suitable with large images depending on computer RAM capacity.
-    :param gpu_id: Number representing the gpu ID for segmentation if available. Default 0.
+    :param gpu_id: Number representing the GPU ID for segmentation if available. Default 0.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.

--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -16,7 +16,8 @@ def axon_segmentation(
                     acquired_resolution,
                     overlap_value=None,
                     no_patch=False,
-                    verbosity_level = 0
+                    gpu_id=0,
+                    verbosity_level=0
                     ):
     '''
     Segment images using IVADOMED.
@@ -28,6 +29,7 @@ def axon_segmentation(
     :param acquired_resolution: isotropic pixel size of the acquired images.
     :param no_patch: If True, the image is segmented without using patches. Default: False. This parameter supersedes
     the "overlap_value" parameter. This option may not be suitable with large images depending on computer RAM capacity.
+    :param gpu_id: Number representing the gpu ID for segmentation if available. Default 0.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.
@@ -49,7 +51,7 @@ def axon_segmentation(
         options["overlap_2D"] = [default_overlap, default_overlap]
 
     # IVADOMED automated segmentation
-    nii_lst, _ = imed_inference.segment_volume(str(path_model), input_filenames, options=options)
+    nii_lst, _ = imed_inference.segment_volume(str(path_model), input_filenames, gpu_id=gpu_id, options=options)
     
     target_lst = [str(axon_suffix), str(myelin_suffix)]
 

--- a/AxonDeepSeg/integrity_test.py
+++ b/AxonDeepSeg/integrity_test.py
@@ -32,7 +32,7 @@ def integrity_test():
 
         # Launch the axon and myelin segmentation on test image sample provided in the installation
         print('Computing the segmentation of axon and myelin on test image.')
-        axon_segmentation(path_testing, [str(path_testing / image)], path_model, acquired_resolution=0.13, overlap_value=[48,48])
+        axon_segmentation(path_testing, [str(path_testing / image)], path_model, acquired_resolution=0.13, gpu_id=0, overlap_value=[48,48])
 
         # Read the ground truth mask and the obtained segmentation mask
         mask = ads.imread(path_testing / 'mask.png')

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -117,6 +117,7 @@ def segment_image(
                 acquired_resolution=None,
                 zoom_factor=1.0,
                 no_patch=False,
+                gpu_id=0,
                 verbosity_level=0):
 
     '''
@@ -128,6 +129,7 @@ def segment_image(
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
     :param zoom_factor: multiplicative constant applied to the pixel size before model inference.
     :param no_patch: If True, the image is segmented without using patches. Default: False.
+    :param gpu_id: Number representing the gpu ID for segmentation if available. Default: 0.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.
@@ -193,7 +195,7 @@ def segment_image(
         axon_segmentation(path_acquisitions_folders=path_acquisition,
                           acquisitions_filenames=[str(path_acquisition / acquisition_name)],
                           path_model_folder=path_model, acquired_resolution=acquired_resolution*zoom_factor,
-                          overlap_value=overlap_value, no_patch=no_patch)
+                          overlap_value=overlap_value, no_patch=no_patch, gpu_id=gpu_id)
 
         if verbosity_level >= 1:
             logger.info(f"Image {path_testing_image} segmented.")
@@ -210,6 +212,7 @@ def segment_folders(path_testing_images_folder, path_model,
                     acquired_resolution=None,
                     zoom_factor=1.0,
                     no_patch=False,
+                    gpu_id=0,
                     verbosity_level=0):
     '''
     Segments the images contained in the image folders located in the path_testing_images_folder.
@@ -221,6 +224,7 @@ def segment_folders(path_testing_images_folder, path_model,
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
     :param zoom_factor: multiplicative constant applied to the pixel size before model inference.
     :param no_patch: If True, the image is segmented without using patches. Default: False.
+    :param gpu_id: Number representing the gpu ID for segmentation if available. Default: 0.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.
@@ -303,7 +307,7 @@ def segment_folders(path_testing_images_folder, path_model,
             axon_segmentation(path_acquisitions_folders=path_testing_images_folder,
                             acquisitions_filenames=[str(path_testing_images_folder  / acquisition_name)],
                             path_model_folder=path_model, acquired_resolution=acquired_resolution*zoom_factor,
-                            overlap_value=overlap_value, no_patch=no_patch)
+                            overlap_value=overlap_value, no_patch=no_patch, gpu_id=gpu_id)
             if verbosity_level >= 1:
                 tqdm.write("Image {0} segmented.".format(str(path_testing_images_folder / file_)))
 
@@ -414,6 +418,14 @@ def main(argv=None):
              'The "--no-patch" flag supersedes the "--overlap" flag. \n'
              'This option may not be suitable with large images depending on computer RAM capacity.'
     )
+    ap.add_argument(
+        "--gpu-id",
+        dest="gpu_id",
+        required=False,
+        type=int,
+        help='Number representing the gpu ID for segmentation if available. Default: 0.',
+        default=0,
+    )
     ap._action_groups.reverse()
 
     # Processing the arguments
@@ -432,6 +444,7 @@ def main(argv=None):
     else:
         zoom_factor = 1.0
     no_patch = bool(args["no_patch"])
+    gpu_id = int(args["gpu_id"])
 
     # check for sweep mode
     sweep_mode = (args["sweeprange"] is not None) & (args["sweeplength"] is not None)
@@ -479,6 +492,7 @@ def main(argv=None):
                         sweep_length=sweep_length,
                         acquired_resolution=psm,
                         no_patch=no_patch,
+                        gpu_id=gpu_id
                     )
                 else:
                     segment_image(
@@ -488,6 +502,7 @@ def main(argv=None):
                         acquired_resolution=psm,
                         zoom_factor=zoom_factor,
                         no_patch=no_patch,
+                        gpu_id=gpu_id,
                         verbosity_level=verbosity_level
                     )
 
@@ -524,6 +539,7 @@ def main(argv=None):
                 acquired_resolution=psm,
                 zoom_factor=zoom_factor,
                 no_patch=no_patch,
+                gpu_id=gpu_id,
                 verbosity_level=verbosity_level
                 )
 

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -446,7 +446,10 @@ def main(argv=None):
     no_patch = bool(args["no_patch"])
     gpu_id = int(args["gpu_id"])
 
-    # check for sweep mode
+    # Check for available GPU IDs
+    ads.check_available_gpus(gpu_id)
+
+    # Check for sweep mode
     sweep_mode = (args["sweeprange"] is not None) & (args["sweeplength"] is not None)
     if sweep_mode:
         sweep_range = [float(args["sweeprange"][0]), float(args["sweeprange"][1])]

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -129,7 +129,7 @@ def segment_image(
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
     :param zoom_factor: multiplicative constant applied to the pixel size before model inference.
     :param no_patch: If True, the image is segmented without using patches. Default: False.
-    :param gpu_id: Number representing the gpu ID for segmentation if available. Default: 0.
+    :param gpu_id: Number representing the GPU ID for segmentation if available. Default: 0.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.
@@ -224,7 +224,7 @@ def segment_folders(path_testing_images_folder, path_model,
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
     :param zoom_factor: multiplicative constant applied to the pixel size before model inference.
     :param no_patch: If True, the image is segmented without using patches. Default: False.
-    :param gpu_id: Number representing the gpu ID for segmentation if available. Default: 0.
+    :param gpu_id: Number representing the GPU ID for segmentation if available. Default: 0.
     :param verbosity_level: Level of verbosity. The higher, the more information is given about the segmentation
     process.
     :return: Nothing.
@@ -423,7 +423,7 @@ def main(argv=None):
         dest="gpu_id",
         required=False,
         type=int,
-        help='Number representing the gpu ID for segmentation if available. Default: 0.',
+        help='Number representing the GPU ID for segmentation if available. Default: 0.',
         default=0,
     )
     ap._action_groups.reverse()

--- a/AxonDeepSeg/zoom_factor_sweep.py
+++ b/AxonDeepSeg/zoom_factor_sweep.py
@@ -39,7 +39,7 @@ def sweep(
     :param sweep_length:        number of equidistant zoom factor values to sample from the range
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
     :param no_patch:            If True, the image is segmented without using patches. Default: False.
-    :param gpu_id:              Number representing the gpu ID for segmentation if available. Default: 0.
+    :param gpu_id:              Number representing the GPU ID for segmentation if available. Default: 0.
     :return: Nothing.
     """
 

--- a/AxonDeepSeg/zoom_factor_sweep.py
+++ b/AxonDeepSeg/zoom_factor_sweep.py
@@ -25,8 +25,9 @@ def sweep(
     overlap_value,
     sweep_range,
     sweep_length,
-    acquired_resolution = None,
-    no_patch=False
+    acquired_resolution=None,
+    no_patch=False,
+    gpu_id=0,
     ):
     """
     Wrapper over segment_image to produce segmentations for zoom factor values within a given range.
@@ -38,6 +39,7 @@ def sweep(
     :param sweep_length:        number of equidistant zoom factor values to sample from the range
     :param acquired_resolution: isotropic pixel resolution of the acquired images.
     :param no_patch:            If True, the image is segmented without using patches. Default: False.
+    :param gpu_id:              Number representing the gpu ID for segmentation if available. Default: 0.
     :return: Nothing.
     """
 
@@ -66,7 +68,8 @@ def sweep(
             overlap_value=overlap_value,
             acquired_resolution=acquired_resolution,
             zoom_factor=zoom_factor,
-            no_patch=no_patch
+            no_patch=no_patch,
+            gpu_id=gpu_id,
         )    
         # move and rename segmentations
         for path_seg in path_seg_outputs:

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -36,7 +36,7 @@ import openpyxl
 import pandas as pd
 import imageio
 
-VERSION = "0.2.22"
+VERSION = "0.2.23"
 
 class ADSsettings:
     """

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -56,6 +56,8 @@ class ADSsettings:
         self.zoom_factor = 1.0
         self.axon_shape = "circle"
         self.gpu_id = 0
+        self.n_gpus = ads_utils.check_available_gpus(None)
+        self.max_gpu_id = self.n_gpus-1 if self.n_gpus > 0 else 0
 
     def on_settings_button(self, event):
         """
@@ -109,7 +111,8 @@ class ADSsettings:
         sizer_gpu_id = wx.BoxSizer(wx.HORIZONTAL)
         gpu_id_tooltip = wx.ToolTip("Number representing the GPU ID for segmentation if available.")
         sizer_gpu_id.Add(wx.StaticText(self.settings_frame, label="GPU ID: "))
-        self.gpu_id_spinCtrl = wx.SpinCtrl(self.settings_frame, min=0, max=100, initial=self.gpu_id)
+        self.gpu_id_spinCtrl = wx.SpinCtrl(self.settings_frame, min=0, max=self.max_gpu_id, initial=self.gpu_id)
+        self.gpu_id_spinCtrl.Enable(bool(self.n_gpus))
         self.gpu_id_spinCtrl.Bind(wx.EVT_SPINCTRL, self.on_gpu_id_changed)
         self.gpu_id_spinCtrl.SetToolTip(gpu_id_tooltip)
         sizer_gpu_id.Add(self.gpu_id_spinCtrl, flag=wx.SHAPED, proportion=1)

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -36,7 +36,7 @@ import openpyxl
 import pandas as pd
 import imageio
 
-VERSION = "0.2.21"
+VERSION = "0.2.22"
 
 class ADSsettings:
     """

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -55,6 +55,7 @@ class ADSsettings:
         self.overlap_value = 48
         self.zoom_factor = 1.0
         self.axon_shape = "circle"
+        self.gpu_id = 0
 
     def on_settings_button(self, event):
         """
@@ -104,6 +105,16 @@ class ADSsettings:
         sizer_axon_shape.Add(self.axon_shape_combobox, flag=wx.SHAPED, proportion=1)
         frame_sizer_h.Add(sizer_axon_shape)
 
+        # Add the gpu_id selection
+        sizer_gpu_id = wx.BoxSizer(wx.HORIZONTAL)
+        gpu_id_tooltip = wx.ToolTip("Number representing the GPU ID for segmentation if available.")
+        sizer_gpu_id.Add(wx.StaticText(self.settings_frame, label="GPU ID: "))
+        self.gpu_id_spinCtrl = wx.SpinCtrl(self.settings_frame, min=0, max=100, initial=self.gpu_id)
+        self.gpu_id_spinCtrl.Bind(wx.EVT_SPINCTRL, self.on_gpu_id_changed)
+        self.gpu_id_spinCtrl.SetToolTip(gpu_id_tooltip)
+        sizer_gpu_id.Add(self.gpu_id_spinCtrl, flag=wx.SHAPED, proportion=1)
+        frame_sizer_h.Add(sizer_gpu_id)
+
         # Add the done button
         sizer_done_button = wx.BoxSizer(wx.HORIZONTAL)
         done_button = wx.Button(self.settings_frame, label="Done")
@@ -122,6 +133,9 @@ class ADSsettings:
 
     def on_axon_shape_combobox_item_selected(self, event):
         self.axon_shape = self.axon_shape_combobox.GetStringSelection()
+
+    def on_gpu_id_changed(self, event):
+        self.gpu_id = self.gpu_id_spinCtrl.GetValue()
 
     def on_done_button(self, event):
         # TODO: make sure every setting is saved
@@ -438,6 +452,7 @@ class ADScontrol(ctrlpanel.ControlPanel):
                     overlap_value=[int(self.settings.overlap_value), int(self.settings.overlap_value)],
                     acquired_resolution=pixel_size_float,
                     zoom_factor=self.settings.zoom_factor,
+                    gpu_id=self.settings.gpu_id,
                     verbosity_level=3
                     )
         except SystemExit as err:

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -260,6 +260,8 @@ The script to launch is called **axondeepseg**. It takes several arguments:
                     The "no-patch" flag supersedes the "overlap" flag.
                     This option may not be suitable with large images depending on computer RAM capacity.
 
+--gpu-id GPU_ID     Number representing the GPU ID for segmentation if available. Default: 0.
+
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:
    ::
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR adds an argument in the CLI and setting in FSLeyes to choose which GPU to use while segmenting.

This feature was already implemented in ivadomed in the `segment_volume` API and is useful when processing large images on our shared GPU clusters.
The default GPU ID `0` is the same as the default in ivadomed.

@Stoyan-I-A, I tried the implementation in the plugin based on the similar implementation of the overlap_value setting. It seems to work fine, let me know if that is ok. We may also need to update the ads_plugin file and/or version after the merge of #700.

## Linked issues
Related to #703.