### PR TITLE
Add warnings related to "no-patch" option

### DIFF
--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import AxonDeepSeg.ads_utils as ads
 from AxonDeepSeg.visualization.merge_masks import merge_masks
 from config import axon_suffix, myelin_suffix, axonmyelin_suffix
+from loguru import logger
 
 from ivadomed import inference as imed_inference
 
@@ -40,6 +41,12 @@ def axon_segmentation(
     options = {"pixel_size": [acquired_resolution, acquired_resolution], "pixel_size_units": "um", "binarize_maxpooling": True}
     if no_patch:
         options["no_patch"] = no_patch
+        logger.warning("The 'no-patch' option was selected for segmentation. "\
+                       "Please note that it may not be suitable with large images depending on computer RAM capacity.")
+    else:
+        logger.warning("The 'no-patch' option was not selected for segmentation. "\
+                       "Please note that this option could potentially produce better results but may not be suitable "\
+                       "with large images depending on computer RAM capacity.")
     if overlap_value:
         # When both no_patch and overlap_value are used, the no_patch option supersedes the overlap_value
         # and a warning will be issued by ivadomed while segmenting without patches.

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -36,7 +36,7 @@ import openpyxl
 import pandas as pd
 import imageio
 
-VERSION = "0.2.21"
+VERSION = "0.2.22"
 
 class ADSsettings:
     """
@@ -111,8 +111,8 @@ class ADSsettings:
         self.no_patch_checkbox = wx.CheckBox(self.settings_frame, label="No patches")
         self.no_patch_checkbox.SetValue(self.no_patch)
         no_patch_checkbox_tooltip = wx.ToolTip("Determines whether or not to split the image into patches. "
-                                               "No patches may not be suitable with large images depending on "
-                                               "computer RAM capacity.")
+                                               "No patches could potentially produce better results but may not be suitable "
+                                               "with large images depending on computer RAM capacity.")
         self.no_patch_checkbox.Bind(wx.EVT_CHECKBOX, self.on_no_patch_checkbox_clicked)
         self.no_patch_checkbox.SetToolTip(no_patch_checkbox_tooltip)
         sizer_no_patch_checkbox.Add(self.no_patch_checkbox, flag=wx.SHAPED, proportion=1)

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -258,7 +258,7 @@ The script to launch is called **axondeepseg**. It takes several arguments:
 
 --no-patch          Flag to segment the image without using patches.
                     The "no-patch" flag supersedes the "overlap" flag.
-                    This option may not be suitable with large images depending on computer RAM capacity.
+                    This option could potentially produce better results but may not be suitable with large images depending on computer RAM capacity.
 
 .. NOTE :: You can get the detailed description of all the arguments of the **axondeepseg** command at any time by using the **-h** argument:
    ::


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [ ] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description

This PR is part of the RAM limitations vs. no-patch segmentation discussion in issue #703.

As discussed in meeting, it adds warnings to the user regarding the "no-patch" option:
* warn the user when using "no-patch" that this may not be suitable for larger images
* warn the user when not using "no-patch" that "no-patch" could potentially produce better results

It also includes an update of documentation and tooltip in fsleyes.

## Linked issues
Related to #703 