### PR TITLE
Change pixel size to reduce RAM usage during no-patch test

### DIFF
--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -401,7 +401,7 @@ class TestCore(object):
     def test_main_cli_runs_succesfully_with_nopatch_and_overlap_flags(self):
 
         with pytest.raises(SystemExit) as pytest_wrapped_e:
-            # Note that the pixel size set here, 0.1, differs from the true size, 0.37, in order to reduce RAM burden GitHub Actions CIs and users computers
+            # Note that the pixel size set here, 0.1, differs from the true size, 0.37, in order to reduce RAM burden on GitHub Actions CIs and users computers
             AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.1", "--no-patch", "--overlap", "48"])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -392,7 +392,8 @@ class TestCore(object):
     def test_main_cli_runs_succesfully_with_nopatch_flag(self):
 
         with pytest.raises(SystemExit) as pytest_wrapped_e:
-            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.37", "--no-patch"])
+            # Note that the pixel size set here, 0.1, differs from the true size, 0.37, in order to reduce RAM burden GitHub Actions CIs and users computers
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.1", "--no-patch"])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
 
@@ -400,7 +401,8 @@ class TestCore(object):
     def test_main_cli_runs_succesfully_with_nopatch_and_overlap_flags(self):
 
         with pytest.raises(SystemExit) as pytest_wrapped_e:
-            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.37", "--no-patch", "--overlap", "48"])
+            # Note that the pixel size set here, 0.1, differs from the true size, 0.37, in order to reduce RAM burden GitHub Actions CIs and users computers
+            AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.1", "--no-patch", "--overlap", "48"])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)
 

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -392,7 +392,7 @@ class TestCore(object):
     def test_main_cli_runs_succesfully_with_nopatch_flag(self):
 
         with pytest.raises(SystemExit) as pytest_wrapped_e:
-            # Note that the pixel size set here, 0.1, differs from the true size, 0.37, in order to reduce RAM burden GitHub Actions CIs and users computers
+            # Note that the pixel size set here, 0.1, differs from the true size, 0.37, in order to reduce RAM burden on GitHub Actions CIs and users computers
             AxonDeepSeg.segment.main(["-t", "SEM", "-i", str(self.imagePath), "-v", "1", "-s", "0.1", "--no-patch"])
 
         assert (pytest_wrapped_e.type == SystemExit) and (pytest_wrapped_e.value.code == 0)


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://www.neuro.polymtl.ca/software/contributing#pr_labels) to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description

Because the Windows and Linux machines that GitHub action uses only have 7GB of ram, occasionally the CI will fail the no-patch tests that were recently added when the memory runs out (it uses approx 6GB). This PR reduces the image sizes via the pixel size for these tests, so that they (hopefully) won't fail anymore during the nightly scheduled CI runs. In addition, this will hopefully prevent some users (not happened yet) from getting fails from running the test suite after installation, also due to insufficient RAM.

## Linked issues

Resolves #706 