### PR TITLE
[Patch] changed colormap used in the FSLeyes plugin

### DIFF
--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -399,11 +399,11 @@ class ADScontrol(ctrlpanel.ControlPanel):
         # Load the masks into FSLeyes
         axon_outfile = self.ads_temp_dir / (image_name + "-axon.png")
         ads_utils.imwrite(axon_outfile, axon_mask)
-        self.load_png_image_from_path(axon_outfile, is_mask=True, colormap="blue")
+        self.load_png_image_from_path(axon_outfile, is_mask=True, colormap="bwr_r")
 
         myelin_outfile = self.ads_temp_dir / (image_name + "-myelin.png")
         ads_utils.imwrite(myelin_outfile, myelin_mask)
-        self.load_png_image_from_path(myelin_outfile, is_mask=True, colormap="red")
+        self.load_png_image_from_path(myelin_outfile, is_mask=True, colormap="bwr")
 
     def on_apply_model_button(self, event):
         """
@@ -795,7 +795,7 @@ class ADScontrol(ctrlpanel.ControlPanel):
                 return im_axonmyelin_label
 
     def load_png_image_from_path(
-        self, image_path, is_mask=False, add_to_overlayList=True, colormap="greyscale"
+        self, image_path, is_mask=False, add_to_overlayList=True, colormap="gray"
     ):
         """
         This function converts a 2D image into a NIfTI image and loads it as an overlay.

--- a/ads_plugin.py
+++ b/ads_plugin.py
@@ -36,7 +36,7 @@ import openpyxl
 import pandas as pd
 import imageio
 
-VERSION = "0.2.23"
+VERSION = "0.2.24"
 
 class ADSsettings:
     """

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - scikit-image=0.19.3
   - tabulate
   - pandas
-  - matplotlib=3.3.4
+  - matplotlib
   - mpld3
   - tqdm
   - requests


### PR DESCRIPTION
## Checklist

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


## Description
The aim of this change is to try to fix an error that happened to a user. I am not 100% sure it will resolve it because I can't reproduce the problem on my end.
This change also seems to have the side effect that we can't change the opacity of the overlay. And if we try to change it in one of the menu settings of FSLeyes it will throw an error. 

To be clear, I don't think this is a good change and I would rather not merge it but it may just solve an issue for a user.

## Linked issues
Resolves #727 
