### PR TITLE
Fix imagio below latest version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - tqdm
   - requests
   - pillow!=9.0.0
-  - imageio
+  - imageio<2.28.0
   - pytest
   - pytest-cov
   - prettytable


### PR DESCRIPTION
Quickfix to temporarily resolve #738 by fixing the imagioio version below the latest version (2.28.0)