### PR TITLE
Save raw instance segmentation

### DIFF
--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -255,7 +255,7 @@ def convert_path(object_path):
         else:
             raise TypeError('Paths, folder names, and filenames must be either strings or pathlib.Path objects. object_path was type: ' + str(type(object_path)))
 
-def imread(filename):
+def imread(filename, bitdepth=8):
     """ Read image and convert it to desired bitdepth without truncation.
     """
 
@@ -280,7 +280,7 @@ def imread(filename):
         raw_img = imageio.v2.imread(filename)
         if len(raw_img.shape) > 2:
             raw_img = imageio.v2.imread(filename, as_gray=True)
-    img = imageio.core.image_as_uint(raw_img, bitdepth=8)
+    img = imageio.core.image_as_uint(raw_img, bitdepth=bitdepth)
     return img
 
 def imwrite(filename, img, format='png'):

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -255,7 +255,7 @@ def get_axon_morphometrics(
         output = (*output, index_image_array)
     
     if return_instance_seg:
-        output = (*output, im_instance_seg)
+        output = (*output, im_instance_seg, im_axonmyelin_label)
 
     return output
 

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -26,7 +26,7 @@ import AxonDeepSeg.ads_utils as ads
 from config import (
     axon_suffix, myelin_suffix, axonmyelin_suffix,
     index_suffix, axonmyelin_index_suffix,
-    morph_suffix, instance_suffix,
+    morph_suffix, instance_im_suffix, instance_suffix,
 )
 from AxonDeepSeg.ads_utils import convert_path
 from AxonDeepSeg import postprocessing, params
@@ -216,7 +216,8 @@ def main(argv=None):
             # unpack the morphometrics output
             stats_dataframe, index_image_array = morph_output[0:2]
             if colorization_flag:
-                instance_seg_image = morph_output[2]
+                instance_seg_image, instance_map = morph_output[2:]
+                instance_map = instance_map.astype(np.uint16)
 
             morph_filename = current_path_target.stem + "_" + filename
 
@@ -243,7 +244,8 @@ def main(argv=None):
                 
                 if colorization_flag:
                     # Save instance segmentation
-                    ads.imwrite(outfile_basename + str(instance_suffix), instance_seg_image)
+                    ads.imwrite(outfile_basename + str(instance_im_suffix), instance_seg_image)
+                    ads.imwrite(outfile_basename + str(instance_suffix), instance_map)
 
                 logger.info("Morphometrics file: {} has been saved in the {} directory",
                     morph_filename,

--- a/config.py
+++ b/config.py
@@ -10,7 +10,8 @@ axonmyelin_index_suffix = Path('_axonmyelin_index.png') # Colored axonmyelin seg
 
 # morphometrics file suffix name
 morph_suffix = Path('axon_morphometrics.xlsx')
-instance_suffix = Path('_instance-map.png')             # Colored instance map of the segmentation
+instance_im_suffix = Path('_colorized.png')             # Colored instance map of the segmentation
+instance_suffix = Path('_instance-map.png')             # Raw instance map
 
 # List of valid image extensions
 valid_extensions = [


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
This PR adds a feature discussed last year in #668 after the instance colorization feature was merged. When using the `-c` flag, the raw instance map is now also saved alongside the colorized image.

Note 2 things: 
- I changed the colorized image suffix from `_instance-map.png` to `_colorized.png` as the former was more appropriate for the raw instance map file.
- I added back the *bitdepth* argument in imread which was removed in #669 (I don't recall why). For now it's useless because the raw instance map (saved in 16bit PNG) is never read anywhere. However, if we want to read a 16-bit instance map, we will be able to use our imread function with `bitdepth=16`.
https://github.com/axondeepseg/axondeepseg/blob/7e042332e7bbf296c0d25ee9cabce377cc6e4275/AxonDeepSeg/ads_utils.py#L258

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #668
Resolves #697 