### PR TITLE
Fix a bug where the error message would not show up if the model couldn't be applied

### DIFF
--- a/plugins/napari_ADS/_widget.py
+++ b/plugins/napari_ADS/_widget.py
@@ -370,7 +370,7 @@ class ADSplugin(QWidget):
         self.apply_model_button.setEnabled(True)
         if not self.apply_model_thread.task_finished_successfully:
             self.show_info_message(
-                "Couldn't apply the ADS model. Check the console for more information"
+                "Couldn't apply the ADS model. Please check the console or terminal for more information."
             )
             return
 
@@ -854,8 +854,8 @@ class ApplyModelThread(QtCore.QThread):
             self.task_finished_successfully = True
         except SystemExit as err:
             if err.code == 4:
-                self.show_info_message(
-                    "Resampled image smaller than model's patch size. Please take a look at your terminal \n"
+                print(
+                    "Resampled image smaller than model's patch size. Please take a look at the lines above \n"
                     "for the minimum zoom factor value to use (option available in the Settings menu)."
                 )
             self.task_finished_successfully = False


### PR DESCRIPTION
## Checklist

- [X] I've given this PR a concise, self-descriptive, and meaningful title
- [X] I've linked relevant issues in the PR body
- [X] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [X] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


## Description
In this discussion: https://github.com/axondeepseg/axondeepseg/discussions/748 , the user encountered a bug when he tried to apply an ADS model on an image that was too small. We would expect to see a pop up message warning the user that the model was not applied but instead an AttributeError was thrown. This PR fixes this issue and the pop up message should correctly be displayed in a case like this.

## Linked issues
Resolves #749 
