### PR TITLE
Remove unicode in units names

### DIFF
--- a/AxonDeepSeg/download_tests.py
+++ b/AxonDeepSeg/download_tests.py
@@ -10,7 +10,7 @@ def download_tests(destination=None):
         destination = convert_path(destination)
         test_files_destination = destination / "__test_files__"
 
-    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20220726.zip"  
+    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20240109.zip"  
     files_before = list(Path.cwd().iterdir())
 
     if (

--- a/AxonDeepSeg/params.py
+++ b/AxonDeepSeg/params.py
@@ -28,7 +28,7 @@ column_names_ordered = [
     Morphometrics_Column_Name('x0', 'x0 (px)'),
     Morphometrics_Column_Name('y0', 'y0 (px)'),
     Morphometrics_Column_Name('gratio'),
-    Morphometrics_Column_Name('axon_area','axon_area (um^2)'), # unicode for ^2
+    Morphometrics_Column_Name('axon_area','axon_area (um^2)'),
     Morphometrics_Column_Name('axon_perimeter','axon_perimeter (um)'),
     Morphometrics_Column_Name('myelin_area', 'myelin_area (um^2)'),
     Morphometrics_Column_Name('axon_diam','axon_diam (um)'),

--- a/AxonDeepSeg/params.py
+++ b/AxonDeepSeg/params.py
@@ -28,11 +28,11 @@ column_names_ordered = [
     Morphometrics_Column_Name('x0', 'x0 (px)'),
     Morphometrics_Column_Name('y0', 'y0 (px)'),
     Morphometrics_Column_Name('gratio'),
-    Morphometrics_Column_Name('axon_area','axon_area (um\u00b2)'), # unicode for ^2
+    Morphometrics_Column_Name('axon_area','axon_area (um^2)'), # unicode for ^2
     Morphometrics_Column_Name('axon_perimeter','axon_perimeter (um)'),
-    Morphometrics_Column_Name('myelin_area', 'myelin_area (um\u00b2)'),
+    Morphometrics_Column_Name('myelin_area', 'myelin_area (um^2)'),
     Morphometrics_Column_Name('axon_diam','axon_diam (um)'),
     Morphometrics_Column_Name('myelin_thickness','myelin_thickness (um)'),
-    Morphometrics_Column_Name('axonmyelin_area','axonmyelin_area (um\u00b2)'),
+    Morphometrics_Column_Name('axonmyelin_area','axonmyelin_area (um^2)'),
     Morphometrics_Column_Name('axonmyelin_perimeter','axonmyelin_perimeter (um)'),
 ]


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The use of unicode to make a superscript in the morphometrics units (eg um^2) is problematic, as different interfaces won't display the same way,

eg Excel
![Screenshot 2024-01-09 at 11 35 44 AM](https://github.com/axondeepseg/axondeepseg/assets/1421029/1aaafc3d-fe3c-4bd5-b5a3-79beb106c978)

eg TextEdit
![Screenshot 2024-01-09 at 11 35 57 AM](https://github.com/axondeepseg/axondeepseg/assets/1421029/cf9f6730-046c-4ec2-b5fd-eb91427f4a62)

and, while it displays correctly in pandas dataframes,

![Screenshot 2024-01-09 at 11 36 24 AM](https://github.com/axondeepseg/axondeepseg/assets/1421029/eaad742d-33aa-4101-8c91-566cfd9ee085)

getting access to the column it's not as simple as copy-pasting the name when using unicode,

![Screenshot 2024-01-09 at 11 38 27 AM](https://github.com/axondeepseg/axondeepseg/assets/1421029/165197bf-4a0c-4d02-a3e3-14f0c4aa21d3)

the user instead needs to go look into our code to find what the unicode was (which we don't instruct them to do),

![Screenshot 2024-01-09 at 11 39 37 AM](https://github.com/axondeepseg/axondeepseg/assets/1421029/922f9afa-47c7-4008-a6fd-d8ea31a64e5b)

I think simply using `um^2` should be understandable by most, and simplifies the use/visualization of the unit name across softwares.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
