### PR TITLE
Support unmyelinated axons in morphometrics

### DIFF
--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -131,7 +131,8 @@ def main(argv=None):
         '-u', '--unmyelinated',
         required=False,
         action='store_true',
-        help='To toggle morphometrics for unmyelinated axons.'
+        help='Toggles morphometrics for unmyelinated axons. This will process masks with the \n'
+            +f'"{unmyelinated_suffix}" suffix.'
     )
 
     # Processing the arguments

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -26,7 +26,7 @@ import AxonDeepSeg.ads_utils as ads
 from config import (
     axon_suffix, myelin_suffix, axonmyelin_suffix,
     index_suffix, axonmyelin_index_suffix,
-    morph_suffix, instance_suffix,
+    morph_suffix, instance_suffix, unmyelinated_suffix
 )
 from AxonDeepSeg.ads_utils import convert_path
 from AxonDeepSeg import postprocessing, params

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -131,8 +131,8 @@ def main(argv=None):
         '-u', '--unmyelinated',
         required=False,
         action='store_true',
-        help='Toggles morphometrics for unmyelinated axons. This will process masks with the \n'
-            +f'"{unmyelinated_suffix}" suffix.'
+        help='Toggles morphometrics for unmyelinated axons. This will only process masks with \n'
+            +f'the "{unmyelinated_suffix}" suffix.'
     )
 
     # Processing the arguments
@@ -163,8 +163,11 @@ def main(argv=None):
         if dir_iter.is_dir(): # batch morphometrics
             flag_morp_batch = True
             target_list += [Path(dir_iter / path_target) for path_target in os.listdir(dir_iter)  \
-                                if Path(path_target).suffix.lower() in validExtensions and not path_target.endswith(str(axon_suffix)) \
-                                and not path_target.endswith(str(myelin_suffix)) and not path_target.endswith(str(axonmyelin_suffix)) \
+                                if Path(path_target).suffix.lower() in validExtensions 
+                                and not path_target.endswith(str(axon_suffix)) \
+                                and not path_target.endswith(str(myelin_suffix)) \
+                                and not path_target.endswith(str(axonmyelin_suffix)) \
+                                and not path_target.endswith(str(unmyelinated_suffix)) \
                                 and ((Path(path_target).stem + str(axonmyelin_suffix)) in os.listdir(dir_iter))]
 
     if flag_morp_batch: # If flag_morph_batch = True, set the path_target_list to target_list.

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -165,6 +165,9 @@ def main(argv=None):
     border_info_flag = args["border_info"]
     colorization_flag = args["colorize"]
     unmyelinated_mode = args["unmyelinated"]
+    if colorization_flag and unmyelinated_mode:
+        logger.warning("ERROR: Colorization not supported for unmyelinated axons. Ignoring the -c flag.")
+        colorization_flag = False
 
     # Tuple of valid file extensions
     validExtensions = (
@@ -226,8 +229,8 @@ def main(argv=None):
 
             # Compute statistics
             morph_output = get_axon_morphometrics(
-                im_axon=pred_axon, 
-                im_myelin=pred_myelin, 
+                im_axon=pred_uaxon if unmyelinated_mode else pred_axon, 
+                im_myelin=None if unmyelinated_mode else pred_myelin, 
                 pixel_size=psm, 
                 axon_shape=axon_shape, 
                 return_index_image=True,
@@ -256,11 +259,12 @@ def main(argv=None):
 
                 ads.imwrite(outfile_basename + str(index_suffix), index_image_array)
                 # Generate the colored image
-                postprocessing.generate_and_save_colored_image_with_index_numbers(
-                    filename=outfile_basename + str(axonmyelin_index_suffix),
-                    axonmyelin_image_path=str(current_path_target.with_suffix("")) + str(axonmyelin_suffix),
-                    index_image_array=index_image_array
-                )
+                if not unmyelinated_mode:
+                    postprocessing.generate_and_save_colored_image_with_index_numbers(
+                        filename=outfile_basename + str(axonmyelin_index_suffix),
+                        axonmyelin_image_path=str(current_path_target.with_suffix("")) + str(axonmyelin_suffix),
+                        index_image_array=index_image_array
+                    )
                 
                 if colorization_flag:
                     # Save instance segmentation

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -127,6 +127,12 @@ def main(argv=None):
         action='store_true',
         help='To save the instance segmentation image.'
     )
+    ap.add_argument(
+        '-u', '--unmyelinated',
+        required=False,
+        action='store_true',
+        help='To toggle morphometrics for unmyelinated axons.'
+    )
 
     # Processing the arguments
     args = vars(ap.parse_args(argv))
@@ -135,6 +141,7 @@ def main(argv=None):
     axon_shape = str(args["axonshape"])
     border_info_flag = args["border_info"]
     colorization_flag = args["colorize"]
+    unmyelinated_mode = args["unmyelinated"]
 
     # Tuple of valid file extensions
     validExtensions = (

--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -258,13 +258,16 @@ def main(argv=None):
                     outfile_basename = str(current_path_target.with_suffix(""))
 
                 ads.imwrite(outfile_basename + str(index_suffix), index_image_array)
-                # Generate the colored image
+                # Generate the colored image; note that its background image is different in unmyelinated mode
                 if not unmyelinated_mode:
-                    postprocessing.generate_and_save_colored_image_with_index_numbers(
-                        filename=outfile_basename + str(axonmyelin_index_suffix),
-                        axonmyelin_image_path=str(current_path_target.with_suffix("")) + str(axonmyelin_suffix),
-                        index_image_array=index_image_array
-                    )
+                    bg_image_path = str(current_path_target.with_suffix("")) + str(axonmyelin_suffix)
+                else:
+                    bg_image_path = str(current_path_target.with_suffix("")) + str(unmyelinated_suffix)
+                postprocessing.generate_and_save_colored_image_with_index_numbers(
+                    filename=outfile_basename + str(axonmyelin_index_suffix),
+                    axonmyelin_image_path=bg_image_path,
+                    index_image_array=index_image_array
+                )
                 
                 if colorization_flag:
                     # Save instance segmentation

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ axon_suffix = Path('_seg-axon.png')                     # axon segmentation suff
 myelin_suffix = Path('_seg-myelin.png')                 # myelin segmentation suffix file name
 index_suffix = Path('_index.png')                       # image with the index of the axons
 axonmyelin_index_suffix = Path('_axonmyelin_index.png') # Colored axonmyelin segmentation + the index image
+unmyelinated_suffix = Path('_seg-uaxon.png')            # unmyelinated axon segmentation suffix file name
 
 # morphometrics file suffix name
 morph_suffix = Path('axon_morphometrics.xlsx')


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
I'll add test/documentation when the feature is ready.

In its current state, this feature can be used as follows:
1. the user specifies the `-u` flag. This will toggle _unmyelinated_mode_ and the morphometrics script will only look for prediction suffixed "_seg-uaxon". Axon and myelin masks will **NOT** be loaded/processed in this mode.
2. a CSV file is saved alongside the `_index` and `_uaxon-index` images.

Note that currently, in _unmyelinated_mode_:
- **colorization** flag is ignored
- **border info** flag is ignored

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #795 