### PR TITLE
Github Actions failure: macos " No installed conda 'base' environment found at !"

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -67,6 +67,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{matrix.python-version}}
+          auto-activate-base: true
           activate-environment: ads_venv
           auto-update-conda: true
           environment-file: environment.yml

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -64,10 +64,8 @@ jobs:
 
       # Step 2: Install environment.
       - name: Install Conda Env All OS
-        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{matrix.python-version}}
-          auto-activate-base: true
           activate-environment: ads_venv
           auto-update-conda: true
           environment-file: environment.yml

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-13", "windows-latest" ]
+        os: [ "ubuntu-latest", "macos-12", "windows-latest" ]
         python-version: [ "3.8" ]
 
     # Main steps for the test to be reproduced across OS x Python

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -64,11 +64,10 @@ jobs:
 
       # Step 2: Install environment.
       - name: Install Conda Env All OS
-        with:
-          python-version: ${{matrix.python-version}}
-          activate-environment: ads_venv
-          auto-update-conda: true
-          environment-file: environment.yml
+        run: |
+          conda update
+          conda install environment.yml
+          conda activate ads_env
 
       # Step 3: List conda info, conda packages
       - name: Conda info and list

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: [ "ubuntu-latest", "macos-13", "windows-latest" ]
         python-version: [ "3.8" ]
 
     # Main steps for the test to be reproduced across OS x Python
@@ -64,10 +64,12 @@ jobs:
 
       # Step 2: Install environment.
       - name: Install Conda Env All OS
-        run: |
-          conda update
-          conda install environment.yml
-          conda activate ads_env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{matrix.python-version}}
+          activate-environment: ads_venv
+          auto-update-conda: true
+          environment-file: environment.yml
 
       # Step 3: List conda info, conda packages
       - name: Conda info and list


### PR DESCRIPTION
## Checklist

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

We've recently started getting this failure on the macos CI:


```shell
Error: No installed conda 'base' environment found at !If you are using this action in a self-hosted runner that already provides its own Miniconda installation, please specify its location with a `CONDA` environment variable. If you want us to download and install Miniconda or Miniforge for you, add `miniconda-version: "latest"` or `miniforge-version: "latest"`, respectively, to the parameters for this action.
```

https://github.com/axondeepseg/axondeepseg/actions/runs/8918691441/job/24493688432

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
