### PR TITLE
Update sphinx to fix doc build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,6 @@ name: docs
 channels:
   - defaults
 dependencies:
-  - sphinx==5.0.0
+  - sphinx>=5.0.0
   - sphinx_rtd_theme>=0.2.4
   - recommonmark

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,6 @@ name: docs
 channels:
   - defaults
 dependencies:
-  - sphinx==4.2.0
+  - sphinx==5.0.0
   - sphinx_rtd_theme>=0.2.4
   - recommonmark


### PR DESCRIPTION
RTD fails on all PRs at the moment. It complains that sphinx should be at least v5.0.0