### PR TITLE
Change "download_models" to "download_model"

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -153,11 +153,11 @@ Here are the details of all the models currently supported by AxonDeepSeg:
 
 To download these models, you must first have AxonDeepSeg installed. Afterwards, run::
 
-    download_model -m <model name> -t <model type>
+    download_models -m <model name> -t <model type>
 
 where <model name> is the full name (e.g. *model_seg_rat_axon-myelin_SEM*) and <model type> is either *light* or *ensemble*. To view available models and their details, run::
 
-    download_model --list
+    download_models --list
 
 Using AxonDeepSeg
 =================

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -153,11 +153,11 @@ Here are the details of all the models currently supported by AxonDeepSeg:
 
 To download these models, you must first have AxonDeepSeg installed. Afterwards, run::
 
-    download_models -m <model name> -t <model type>
+    download_model -m <model name> -t <model type>
 
 where <model name> is the full name (e.g. *model_seg_rat_axon-myelin_SEM*) and <model type> is either *light* or *ensemble*. To view available models and their details, run::
 
-    download_models --list
+    download_model --list
 
 Using AxonDeepSeg
 =================

--- a/install_ads
+++ b/install_ads
@@ -670,7 +670,7 @@ cp "$ADS_DIR/$CONDA_DIR/envs/venv_ads/bin/napari" "$ADS_DIR/$BIN_DIR/ads_napari"
 echo "source $ADS_DIR/ads_conda/bin/activate $ADS_DIR/ads_conda/envs/venv_ads/" > "$ADS_DIR/$BIN_DIR/ads_activate"
 chmod +x "$ADS_DIR/$BIN_DIR/ads_activate"
 
-# Activate the launchers, particularly download_models, download_tests, and axondeepseg_test
+# Activate the launchers, particularly download_model, download_tests, and axondeepseg_test
 export PATH="$ADS_DIR/$BIN_DIR:$PATH"
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -683,7 +683,7 @@ if [[ -n "$NO_DATA_INSTALL" ]]; then
 else
   # Download data
   print info "Installing data..."
-  download_models
+  download_model
   download_tests
 fi
 

--- a/install_ads.bat
+++ b/install_ads.bat
@@ -189,7 +189,7 @@ ads_conda\envs\venv_ads\Scripts\pip install -e . plugins\ --use-pep517 || goto e
 rem Install external dependencies
 echo:
 echo ### Downloading model files and test data...
-ads_conda\envs\venv_ads\Scripts\download_models
+ads_conda\envs\venv_ads\Scripts\download_model
 ads_conda\envs\venv_ads\Scripts\download_tests
 
 rem Copying ADS scripts to an isolated folder (so we can add scripts to the PATH without adding the entire venv_ads)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class PostDevelopCommand(develop):
     def run(self):
 
         develop.run(self)
-        check_call("download_models")
+        check_call("download_model")
         check_call("download_tests")
 
 
@@ -52,7 +52,7 @@ setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-           'download_models = AxonDeepSeg.download_model:main',
+           'download_model = AxonDeepSeg.download_model:main',
            'download_tests = AxonDeepSeg.download_tests:main',
            'axondeepseg = AxonDeepSeg.segment:main',
            'axondeepseg_test = AxonDeepSeg.integrity_test:integrity_test', 

--- a/test/test_download_models.py
+++ b/test/test_download_models.py
@@ -41,7 +41,7 @@ class TestCore(object):
             shutil.rmtree(tmpPath)
             pass
 
-    # --------------download_models tests-------------- #
+    # --------------download_model tests-------------- #
     @pytest.mark.unit
     def test_download_valid_model_works(self):
 
@@ -60,7 +60,7 @@ class TestCore(object):
 
 
     @pytest.mark.unit
-    def test_redownload_models_multiple_times_works(self):
+    def test_redownload_model_multiple_times_works(self):
 
         download_model(self.valid_model, 'light', self.tmpPath)
         download_model(self.valid_model, 'light', self.tmpPath)

--- a/test/test_download_tests.py
+++ b/test/test_download_tests.py
@@ -43,7 +43,7 @@ class TestCore(object):
             shutil.rmtree(tmpPath)
             pass
 
-    # --------------download_models tests-------------- #
+    # --------------download_model tests-------------- #
     @pytest.mark.unit
     def test_download_tests_works(self):
         assert not self.test_files_path.exists()


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

The documentation currently says to the users to call `download_model`, however our actual CLI command is `download_models`. As a simple fix, we can simply update the doc; however, it is a bit inconsistent that in actuality, our python **module** name is `download_model` (and makes more sense, since we can only download one model at a time I believe). So maybe changing the CLI command would be a better solution considering we're releasing 5.0 soon (this would require more changes though in the tests, installation, and CI files). Open to opinions/discussion

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

#829 