### PR TITLE
Pin acvl_utils!=0.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ jupyter
 openpyxl
 qtconsole<5.4.2
 napari
-acvl_utils<0.2.1
+acvl_utils!=0.2.1
 nnunetv2==2.2.1
 loguru
 torch<2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ jupyter
 openpyxl
 qtconsole<5.4.2
 napari
+acvl_utils<0.2.1
 nnunetv2==2.2.1
 loguru
 torch<2.4.0


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

nnUnetV2 depends on acvl_utils, but didn't pin a version for it. Two days ago acvl_utils == 0.2.1 was released, but that one imports a package that is never installed (blosc2) which has lead to failing overnight tests, https://github.com/axondeepseg/axondeepseg/actions/runs/11753375787

I propose to pin the version to <0.2.1, because if acvl_utils didn't catch this missing dependency with tests or a CI, then maybe it's better to trust that they didn't miss something else in this most recent push and download an earlier version.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
