### PR TITLE
Pin skimage<0.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy<2
 scipy
-scikit-image
+scikit-image<0.25
 tabulate
 pandas
 matplotlib


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->


Four days ago, our nightly GithubAction CI tests started failing,

https://github.com/axondeepseg/axondeepseg/actions/runs/12366489905

A single test is failing, one that ensures consistency of the calculated morphometrics values from a test image vs one that was saved when the test was written (or updated),

```

=========================== short test summary info ============================
FAILED test/morphometrics/test_compute_morphometrics.py::TestCore::test_morphometrics_consistency - assert False
 +  where False = <function allclose at 0x7fb8f4055b30>(array([0.5720214 , 0.74337605, 0.31622777, 0.69370799, 0.81355151,\n       0.49859711, 0.52833806, 0.66483182, 0.68028435, 0.79613784,\n       0.81899995, 0.5204165 , 0.38240889, 0.49708452, 0.38506605,\n       0.61509379, 0.55229652, 0.68398557, 0.66759543, 0.63136522,\n       0.4826059 , 0.73413217, 0.58437333, 0.51898071, 0.70300916,\n       0.73051615, 0.72270178, 0.63118935, 0.67475317, 0.63937622,\n       0.60420215, 0.59661913, 0.36359784, 0.77625003, 0.63056875,\n       0.55552897, 0.68297764, 0.60561018, 0.77960365, 0.73508234,\n       0.78712465, 0.64777631, 0.62576663, 0.53643112, 0.83163609,\n       0.54759924, 0.53297613, 0.65474629, 0.71419045, 0.68094768,\n       0.57710599, 0.72876902, 0.54165342, 0.64168895, 0.67525334,\n       0.66190604, 0.15514516, 0.57284125, 0.59500462, 0.62155249,\n       0.61757449, 0.4472136 , 0.60781366, 0.62154683, 0.32831724,\n       0.6371216 , 0.58111155, 0.6589395 , 0.66102778, 0.45098762,\n       0.6971236 , 0.62202563, 0.51075392, 0.68534945, 0.58879413,\n       0.67573257, 0.57110327, 0.63283063, 0.50421948, 0.60753822,\n       0.56611427, 0.63659908, 0.50333411, 0.67050179, 0.72398027,\n       0.33687808, 0.66608555, 0.54787392, 0.50286535, 0.66...099, 0.60580408,\n       0.68943263, 0.64257097, 0.60773183, 0.64013837, 0.44655415,\n       0.26858761, 0.56392508, 0.84907611, 0.57008771, 0.71143271,\n       0.63772365, 0.56838665, 0.6709049 , 0.62267775, 0.59357527,\n       0.84962009, 0.56813476, 0.67263312, 0.62588137, 0.65425419,\n       0.70306449, 0.60744848, 0.59011464, 0.48909186, 0.59298062,\n       0.54992202, 0.74432044, 0.66109621, 0.57462819, 0.59486664,\n       0.5253323 , 0.39735971, 0.60647843, 0.74900721, 0.68131005,\n       0.60433721, 0.83157484, 0.60686608, 0.64422475, 0.6272828 ,\n       0.66573665, 0.48867778, 0.63273836, 0.65018499, 0.46774283,\n       0.72849446, 0.53893029, 0.63915534, 0.71197784, 0.59440079,\n       0.53531417, 0.78185734, 0.57735027, 0.70239493, 0.55356079,\n       0.66762825, 0.69264499, 0.78352421, 0.64856374, 0.80716488,\n       0.58632297, 0.64773854, 0.55807059, 0.57078313, 0.5935346 ,\n       0.53826451, 0.63027776, 0.61006228, 0.7014531 , 0.664459  ,\n       0.86091606, 0.64800727, 0.76715897, 0.62529957, 0.58375023,\n       0.70025331, 0.60422692, 0.82892494, 0.68156503, 0.40734807,\n       0.43337889, 0.58609114, 0.62775392, 0.68646206, 0.46204236,\n       0.46419608, 0.30367585, 0.22176638]), array([0.57161757, 0.74337605, 0.31622777, 0.69392153, 0.81355151,\n       0.49859711, 0.52833806, 0.66483182, 0.68028435, 0.79613784,\n       0.81899995, 0.5204165 , 0.38240889, 0.49684386, 0.38506605,\n       0.61509379, 0.55229652, 0.68398557, 0.66759543, 0.63145402,\n       0.4826059 , 0.73413217, 0.58437333, 0.51898071, 0.70300916,\n       0.73051615, 0.72270178, 0.63118935, 0.67475317, 0.63937622,\n       0.60420215, 0.59661913, 0.36359784, 0.77625003, 0.63056875,\n       0.55552897, 0.68297764, 0.60561018, 0.77960365, 0.73508234,\n       0.78712465, 0.64777631, 0.62576663, 0.53643112, 0.83165187,\n       0.54759924, 0.53297613, 0.65474629, 0.71419045, 0.68094768,\n       0.57710599, 0.72876902, 0.54165342, 0.64168895, 0.67525334,\n       0.66190604, 0.15514516, 0.57284125, 0.59500462, 0.62155249,\n       0.61757449, 0.4472136 , 0.60781366, 0.62154683, 0.32810425,\n       0.6371216 , 0.58111155, 0.6589395 , 0.66102778, 0.45098762,\n       0.6971236 , 0.62202563, 0.51075392, 0.68534945, 0.58879413,\n       0.67573257, 0.57110327, 0.63283063, 0.50421948, 0.60753822,\n       0.56611427, 0.63659908, 0.50333411, 0.67050179, 0.72398027,\n       0.33687808, 0.66608555, 0.54787392, 0.50286535, 0.66...099, 0.60580408,\n       0.68943263, 0.64257097, 0.60773183, 0.64013837, 0.44655415,\n       0.26858761, 0.56392508, 0.84907611, 0.57008771, 0.71143271,\n       0.63772365, 0.56838665, 0.6709049 , 0.62267775, 0.59357527,\n       0.84962009, 0.56813476, 0.67263312, 0.62588137, 0.65425419,\n       0.70306449, 0.60744848, 0.59011464, 0.48939368, 0.59298062,\n       0.54992202, 0.74432044, 0.66109621, 0.57462819, 0.59486664,\n       0.5253323 , 0.39324188, 0.60999428, 0.74900721, 0.68131005,\n       0.60433721, 0.83157484, 0.60686608, 0.64422475, 0.6272828 ,\n       0.66573665, 0.48867778, 0.63273836, 0.65018499, 0.46774283,\n       0.72849446, 0.53893029, 0.63915534, 0.71197784, 0.59440079,\n       0.53164939, 0.78185734, 0.57735027, 0.70239493, 0.55623041,\n       0.66762825, 0.69264499, 0.78352421, 0.64856374, 0.80716488,\n       0.58632297, 0.64773854, 0.55807059, 0.57078313, 0.5935346 ,\n       0.53826451, 0.63027776, 0.61006228, 0.7014531 , 0.664459  ,\n       0.86091606, 0.64800727, 0.76715897, 0.62529957, 0.58375023,\n       0.70025331, 0.60422692, 0.82892494, 0.68156503, 0.40734807,\n       0.43337889, 0.58609114, 0.62775392, 0.68646206, 0.46204236,\n       0.46419608, 0.30367585, 0.22176638]), rtol=0, atol=1e-11, equal_nan=True)
 +    where <function allclose at 0x7fb8f4055b30> = np.allclose
============ 1 failed, 133 passed, 11 warnings in 355.09s (0:05:55) ============
Error: Process completed with exit code 1.

```

Looking at the raw values table, this test fails for the gratio values (but due to a loop in the test, might fail for others).

Only a few values are different, and the diffrerence not anything substantial in absolute value:

<img width="292" alt="Screenshot 2024-12-17 at 12 50 00 PM" src="https://github.com/user-attachments/assets/0556c164-9339-49f0-9bfd-e6ccfb7ca5d7" />
<img width="292" alt="Screenshot 2024-12-17 at 12 50 03 PM" src="https://github.com/user-attachments/assets/62a260a2-ff99-49a6-9b2e-c12a92046d54" />
<img width="292" alt="Screenshot 2024-12-17 at 12 50 07 PM" src="https://github.com/user-attachments/assets/ef8caec8-84b5-4245-8379-2693759865ef" />
<img width="292" alt="Screenshot 2024-12-17 at 12 50 11 PM" src="https://github.com/user-attachments/assets/decf61c0-ebb3-4a30-9d0b-66e6f9bf087f" />
<img width="292" alt="Screenshot 2024-12-17 at 12 50 14 PM" src="https://github.com/user-attachments/assets/ec965a3f-d536-4992-b6ca-87c2fb819304" />

I looked at what modules the gratio calculation uses, and the main external one is scikit-image via `regionprops`. As it would happen, scikit-image released v0.25.0 4 days ago. So, highly likely the culprit, which will be confirmed if the tests in this PR pass from pinning it to <0.25.0.

Looking into the changelog that release, the only mention of a change related to regionprops is via this PR, "Ensure that RegionProperties objects returned by skimage.measure.regionprops can be deserialized with pickle (https://github.com/scikit-image/scikit-image/pull/7569).", and we do in fact open a pickled version of the values for the morphometrics test via this file:  https://github.com/axondeepseg/data-testing/tree/main/__test_files__/__test_demo_files__/__morphometrics__

What I find odd though is how the values are changing, why only some values/metrics (gratio) and why only certain axon objects and not others. Lastly, I'm wondering if this change *fixed* something (i.e. maybe our originally saved values weren't being opened correctly? but that would mean that the consistency tests should have been failing....), or possibly *introduced* a bug that we should report to scikit image. The third option might be that some other PR changed code for this release that indirectly changed our gratio values (via avf/mvf values), but I feel like this is less likely for now.





