### PR TITLE
README: Add dark/light mode compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-<img src="https://github.com/neuropoly/axondeepseg/blob/master/docs/source/_static/logo_ads-alpha.png" width="385">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-dark.png?raw=true" width="385">
+  <img alt="" src=https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-light.png?raw=true" width="385">
+</picture>
+
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/neuropoly/axondeepseg/master?filepath=notebooks%2Fgetting_started.ipynb)
 [![Build Status](https://github.com/axondeepseg/axondeepseg/actions/workflows/run_tests.yaml/badge.svg)](https://github.com/axondeepseg/axondeepseg/actions/workflows/run_tests.yaml)
@@ -11,7 +16,7 @@ Based on a convolutional neural network architecture. Pixels are classified as e
 
 For more information, see the [documentation website](http://axondeepseg.readthedocs.io/).
 
-![alt tag](https://raw.githubusercontent.com/axondeepseg/doc-figures/main/index/fig0.png)
+![alt tag](https://github.com/axondeepseg/doc-figures/blob/main/animations/napari.gif?raw=true)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-dark-alpha.png?raw=true" width="385">
-  <img alt="" src=https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-alpha.png?raw=true" width="385">
+  <img alt="ADS logo (simplified image of segmented axons/myelin in blue and red beside the text 'AxonDeepSeg')" src=https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-alpha.png?raw=true" width="385">
 </picture>
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-dark.png?raw=true" width="385">
-  <img alt="" src=https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-light.png?raw=true" width="385">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-dark-alpha.png?raw=true" width="385">
+  <img alt="" src=https://github.com/axondeepseg/doc-figures/blob/main/logo/logo_ads-alpha.png?raw=true" width="385">
 </picture>
 
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Currently, our logo appeared terrible for users with the dark mode setting,

eg

### Light mode (OLD)

<img width="610" alt="Screenshot 2024-12-19 at 8 23 02 PM" src="https://github.com/user-attachments/assets/05e3731f-bb96-4632-9d2a-7e505185540e" />


### Dark mode (OLD)

<img width="610" alt="Screenshot 2024-12-19 at 8 23 14 PM" src="https://github.com/user-attachments/assets/dcc89fb0-acf4-4a70-8e14-842f3872cac7" />

With this PR, the logo will alternate between two PNGs (with transparent backgrounds) for light/dark mode, the only difference between the two being the text color (black/white).

### Light mode (NEW)

<img width="610" alt="Screenshot 2024-12-19 at 8 23 31 PM" src="https://github.com/user-attachments/assets/1ac942b1-d128-4402-8dad-0c93cfef31df" />


### Dark mode (NEW)

<img width="610" alt="Screenshot 2024-12-19 at 8 23 40 PM" src="https://github.com/user-attachments/assets/edfed642-f53f-4e38-b84e-df2696ab3129" />

I also replaced the U-net figure with a new napari GUI GIF we introduced in our RTD in a recent PR (#850)

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #480