### PR TITLE
Make get_existing_models_list returns None when no models exist

### DIFF
--- a/AxonDeepSeg/ads_utils.py
+++ b/AxonDeepSeg/ads_utils.py
@@ -192,6 +192,11 @@ def get_existing_models_list():
     """
     ADS_path = os.path.dirname(os.path.realpath(__file__))
     models_path = os.path.join(ADS_path, "models")
+
+    # If models folder doesn't exist or it's empty, return None
+    if not os.path.exists(models_path) or not os.listdir(models_path):
+        return None
+
     models_list = next(os.walk(models_path))[1]
     if "__pycache__" in models_list:
         models_list.remove("__pycache__")

--- a/test/test_download_tests.py
+++ b/test/test_download_tests.py
@@ -58,7 +58,7 @@ class TestCore(object):
 
         download_tests(self.tmpPath)
 
-    @pytest.mark.single
+    @pytest.mark.unit
     def test_precision_images_expected_types(self):
 
         precision_path = Path('test/__test_files__/__test_precision_files__')


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->
## Description

This PR exists to solve a problem that isn't here yet, i.e. I only discovered it after trying the pypi route. Basically, currently the installation procedure is guaranteed to always download the models otherwise the installation fails, due to some embedded checks (running the unit tests) and explicit downloading of the data.

When we later switch to offer a pipy install, this won't be the case. And, due to the switch from setup.py to pyproject.toml, there's not really a way to do it either (and it's mainly discouraged to try and get around it); usually they recommend to tell the user to run some kind of axondeepseg init to do all that data-related stuff.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #878 
