### PR TITLE
Fix bug loading predictions of grayscale converted img

### DIFF
--- a/AxonDeepSeg/ads_napari/_widget.py
+++ b/AxonDeepSeg/ads_napari/_widget.py
@@ -524,6 +524,10 @@ class ADSplugin(QWidget):
         selected_layer = self.apply_model_thread.selected_layer
         image_directory = self.apply_model_thread.image_directory
         image_name_no_extension = selected_layer.name
+        # check if segment.prepare_inputs changed the target name
+        potential_target_name = image_name_no_extension + "_grayscale.png"
+        if (image_directory / potential_target_name).exists():
+            image_name_no_extension += '_grayscale'
         axon_mask_path = image_directory / (
             image_name_no_extension + str(axon_suffix)
         )

--- a/test/ads_napari/test_widget.py
+++ b/test/ads_napari/test_widget.py
@@ -17,7 +17,6 @@ import copy
 import time
 import sys
 import shutil
-import trace 
 
 class ImageLoadedEvent(object):
     def __init__(self, data):
@@ -61,7 +60,7 @@ class TestCore(object):
 
     # ------------------User Workflow tests------------------ #
     @pytest.mark.skipif(sys.platform == 'linux', reason="Can't test GUI on Linux")
-    @pytest.mark.single
+    @pytest.mark.integration
     def test_rgb_to_greyscale_user_workflow(self, make_napari_viewer, qtbot):
         ## User opens plugin
         viewer = make_napari_viewer(show=False)


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [ ] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
This is a quick fix for the bug encountered by the UBC group with the latest version of ADS. The fix I suggest is pretty minimal - I don't know where else this grayscale conversion could be a problem in the plugin.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Fixes #894 