### PR TITLE
Create true alias for ads_activate

### DIFF
--- a/install_ads
+++ b/install_ads
@@ -298,7 +298,9 @@ function edit_shellrc() {
     # add line
     echo ""
     # Add ads_activate alias
-    alias ads_activate="source $ADS_DIR/ads_conda/bin/activate $ADS_DIR/ads_conda/envs/venv_ads/venv_ads/"
+    echo "alias ads_activate=\"source $ADS_DIR/ads_conda/bin/activate $ADS_DIR/ads_conda/envs/venv_ads/venv_ads/\""
+    # add line
+    echo ""
   ) >> "$RC_FILE_PATH"
 }
 

--- a/install_ads
+++ b/install_ads
@@ -297,6 +297,8 @@ function edit_shellrc() {
     fi
     # add line
     echo ""
+    # Add ads_activate alias
+    alias ads_activate="source $ADS_DIR/ads_conda/bin/activate $ADS_DIR/ads_conda/envs/venv_ads/venv_ads/"
   ) >> "$RC_FILE_PATH"
 }
 
@@ -653,8 +655,6 @@ for file in "$ADS_DIR/$CONDA_DIR"/envs/venv_ads/bin/*download*; do
   cp "$file" "$ADS_DIR/$BIN_DIR/" || die "Problem creating launchers!"
 done
 cp "$ADS_DIR/$CONDA_DIR/envs/venv_ads/bin/napari" "$ADS_DIR/$BIN_DIR/ads_napari" || die "Problem creating launchers!"
-echo "source $ADS_DIR/ads_conda/bin/activate venv_ads" > "$ADS_DIR/$BIN_DIR/ads_activate"
-chmod +x "$ADS_DIR/$BIN_DIR/ads_activate"
 
 # Activate the launchers, particularly download_model, download_tests, and axondeepseg_test
 export PATH="$ADS_DIR/$BIN_DIR:$PATH"

--- a/install_ads
+++ b/install_ads
@@ -653,7 +653,7 @@ for file in "$ADS_DIR/$CONDA_DIR"/envs/venv_ads/bin/*download*; do
   cp "$file" "$ADS_DIR/$BIN_DIR/" || die "Problem creating launchers!"
 done
 cp "$ADS_DIR/$CONDA_DIR/envs/venv_ads/bin/napari" "$ADS_DIR/$BIN_DIR/ads_napari" || die "Problem creating launchers!"
-echo "source $ADS_DIR/ads_conda/bin/activate $ADS_DIR/ads_conda/envs/venv_ads/" > "$ADS_DIR/$BIN_DIR/ads_activate"
+echo "source $ADS_DIR/ads_conda/bin/activate venv_ads" > "$ADS_DIR/$BIN_DIR/ads_activate"
 chmod +x "$ADS_DIR/$BIN_DIR/ads_activate"
 
 # Activate the launchers, particularly download_model, download_tests, and axondeepseg_test


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [ ] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions


<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

I encountered an issue where our alias `ads_activate` would not work on a new user account on my laptop; after discussing with @joshuacwnewton we found that the culprit is that our current file in the /bin opens in a subprocess, thus not activating it in certain cases. Creating a true alias in the users zsh (or wtv) file resolves this