### PR TITLE
Use skimage.measure.label with 1-connectivity 

### DIFF
--- a/AxonDeepSeg/download_tests.py
+++ b/AxonDeepSeg/download_tests.py
@@ -27,7 +27,8 @@ def download_tests(destination=None, overwrite=True):
         logger.info("Overwrite set to False - not deleting old test files.")
         return test_files_destination
 
-    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20250110.zip"
+    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20250409.zip"
+    
     files_before = list(Path.cwd().iterdir())
 
     if (

--- a/AxonDeepSeg/download_tests.py
+++ b/AxonDeepSeg/download_tests.py
@@ -27,7 +27,7 @@ def download_tests(destination=None, overwrite=True):
         logger.info("Overwrite set to False - not deleting old test files.")
         return test_files_destination
 
-    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20250409.zip"
+    url_tests = "https://github.com/axondeepseg/data-testing/archive/refs/tags/r20250410.zip"
     
     files_before = list(Path.cwd().iterdir())
 

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -115,7 +115,7 @@ def get_axon_morphometrics(
         pixelsize = pixel_size
 
     # Label each axon object
-    im_axon_label = measure.label(im_axon)
+    im_axon_label = measure.label(im_axon, connectivity=1)
     # Measure properties for each axon object
     axon_objects = measure.regionprops(im_axon_label)
 

--- a/AxonDeepSeg/morphometrics/compute_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/compute_morphometrics.py
@@ -115,7 +115,8 @@ def get_axon_morphometrics(
         pixelsize = pixel_size
 
     # Label each axon object
-    im_axon_label = measure.label(im_axon, connectivity=1)
+    connectivity = 1 if im_myelin is None else 2
+    im_axon_label = measure.label(im_axon, connectivity=connectivity)
     # Measure properties for each axon object
     axon_objects = measure.regionprops(im_axon_label)
 

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -54,6 +54,10 @@ class TestCore(object):
         bad_pred_myelin_path = self.test_folder_path / ('invalid_gratio' + str(myelin_suffix))
         self.bad_pred_myelin = ads.imread(bad_pred_myelin_path)
 
+        # To ensure 1-connectivity during object separation
+        connected_components_path = self.testPath / '__test_files__' / '__test_postprocessing_files__' / 'test_connectivity.png'
+        self.connected_components = ads.imread(connected_components_path)
+
         # simulated image of axon myelin where axon shape is circle; `plane angle = 0`
         self.path_sim_image_circle = (
             self.testPath /
@@ -913,3 +917,9 @@ class TestCore(object):
         obtained_watershed = (get_watershed_segmentation(im_axon, im_myelin)).astype(np.uint8)
 
         assert np.array_equal(obtained_watershed, reference_watershed_seg_data)
+
+    @pytest.mark.unit
+    def test_get_axon_morphometrics_uses_expected_connectivity_param(self):
+        img = self.connected_components
+        stats_dataframe = get_axon_morphometrics(im_axon=img)        
+        assert len(stats_dataframe) == 3

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -921,7 +921,7 @@ class TestCore(object):
     @pytest.mark.unit
     def test_get_axon_morphometrics_uses_expected_connectivity_param(self):
         img = self.connected_components
-        stats_dataframe = get_axon_morphometrics(im_axon=img)     
+        stats_dataframe = get_axon_morphometrics(im_axon=img, pixel_size=1)     
 
         # using 1-connectivity, this image has 3 connected components;
         # using 2-connectivity, this image has 2 connected components instead   

--- a/test/morphometrics/test_compute_morphometrics.py
+++ b/test/morphometrics/test_compute_morphometrics.py
@@ -921,5 +921,8 @@ class TestCore(object):
     @pytest.mark.unit
     def test_get_axon_morphometrics_uses_expected_connectivity_param(self):
         img = self.connected_components
-        stats_dataframe = get_axon_morphometrics(im_axon=img)        
+        stats_dataframe = get_axon_morphometrics(im_axon=img)     
+
+        # using 1-connectivity, this image has 3 connected components;
+        # using 2-connectivity, this image has 2 connected components instead   
         assert len(stats_dataframe) == 3


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
This is mostly critical for unmyelinated axons, as the only object separation (from semantic seg to instance seg) is done with `skimage.measure.label` (whereas myelinated axons undergo a subsequent watershed segmentation step). I implemented a test that should fail with the current implementation (where we use 2-connectivity). See issue below for more details.

The image I added to the data-testing repo is the following:
![image](https://github.com/user-attachments/assets/9847126e-a0a9-48c7-9d49-4d4a1fcbda38)
Using 2-connectivity, objects 1 and 2 will be identified as a single instance. 1-connectivity fixes this.

## Linked issues
Resolves #909 
