### PR TITLE
Leverage up to 4x speedups available on Mac ARM via CoreML + general speedups

### DIFF
--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "macos-26-intel", "windows-latest"]
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest"]
         python-version:  [ "3.11", "3.12"]
 
     # Main steps for the test to be reproduced across OS x Python

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "macos-26-intel", "windows-latest"]
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: [ ">=3.11" ]
 
     # Main steps for the test to be reproduced across OS x Python

--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -194,6 +194,8 @@ def axon_segmentation(
     # iterator, and never parallelises the forward pass. Measured on an M5 it lost
     # at every batch size tried (9, 15 and 64 images) while producing byte-identical
     # output, so AxonDeepSeg always takes the sequential path.
+    # Note: predict_from_files_sequential is an internal nnunetv2 method; verify it
+    # still exists when bumping the nnunetv2==2.8.1 pin in pyproject.toml.
     predictor.predict_from_files_sequential(
         list_of_lists_or_source_folder=input_list,
         output_folder_or_list_of_truncated_output_files=output_list,

--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -15,7 +15,7 @@ from AxonDeepSeg.params import nnunet_suffix, intensity
 os.environ['nnUNet_raw'] = 'UNDEFINED'
 os.environ['nnUNet_results'] = 'UNDEFINED'
 os.environ['nnUNet_preprocessed'] = 'UNDEFINED'
-from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor
+from AxonDeepSeg.fast_predictor import AdsPredictor
 
 def get_checkpoint_name(checkpoint_folder_path: Path) -> str:
     '''
@@ -121,6 +121,8 @@ def axon_segmentation(
                     gpu_id: int=-1,
                     verbosity_level: int=0,
                     allow_large_images: bool=False,
+                    backend: str='auto',
+                    tile_step_size: float=0.5,
                     ) -> NoReturn:
     '''
     Segment images by applying a nnU-Net pretrained model.
@@ -128,7 +130,7 @@ def axon_segmentation(
     Parameters
     ----------
     path_inputs : List[pathlib.Path]
-        List of images to segment. We assume they all exist and are already in 
+        List of images to segment. We assume they all exist and are already in
         the correct format expected by the model (nb of channels, image format).
     path_model : pathlib.Path
         Path to the folder of the nnU-Net pretrained model. We assume it exists.
@@ -138,6 +140,12 @@ def axon_segmentation(
         GPU ID to use for cuda acceleration. -1 to use CPU, by default -1.
     verbosity_level : int, optional
         Level of verbosity, by default 0.
+    backend : str, optional
+        Execution backend for the forward pass: 'auto', 'torch', 'torch-fp16' or
+        'coreml'. By default 'auto', which picks the fastest one available.
+    tile_step_size : float, optional
+        Sliding-window overlap, by default 0.5. Larger means fewer, less
+        overlapping tiles: faster and slightly less accurate.
     '''
     # Raise PIL's pixel limit before nnUNet spawns its workers so that large images
     # can be read during preprocessing. On Linux (fork), workers inherit the parent's
@@ -158,7 +166,9 @@ def axon_segmentation(
     else:
         device = torch.device('cpu')
     # instantiate predictor
-    predictor = nnUNetPredictor(
+    predictor = AdsPredictor(
+        backend=backend,
+        tile_step_size=tile_step_size,
         perform_everything_on_device=True if device.type == 'cuda' else False,
         device=device,
     )
@@ -180,7 +190,11 @@ def axon_segmentation(
     data_format = predictor.dataset_json['file_ending'] # e.g. '.png'
     output_list = [ str(p).replace(data_format, target_suffix) for p in path_inputs ]
 
-    predictor.predict_from_files(
+    # nnU-Net's pooled path spawns 8 export workers plus a 3-worker preprocessing
+    # iterator, and never parallelises the forward pass. Measured on an M5 it lost
+    # at every batch size tried (9, 15 and 64 images) while producing byte-identical
+    # output, so AxonDeepSeg always takes the sequential path.
+    predictor.predict_from_files_sequential(
         list_of_lists_or_source_folder=input_list,
         output_folder_or_list_of_truncated_output_files=output_list,
         save_probabilities=False,

--- a/AxonDeepSeg/fast_predictor.py
+++ b/AxonDeepSeg/fast_predictor.py
@@ -71,11 +71,15 @@ def _cache_dir() -> Path:
 
 def coreml_available() -> bool:
     '''
-    Whether the CoreML backend is worth using here. Restricted to Apple silicon:
-    the speedup comes from the Neural Engine, which Intel Macs lack.
+    Whether the CoreML backend is worth using here. Restricted to Apple silicon
+    on macOS 14+: the speedup comes from the Neural Engine, which Intel Macs
+    lack, and the converted model requires macOS 14 (minimum_deployment_target).
     '''
     import platform
     if platform.system() != 'Darwin' or platform.machine() != 'arm64':
+        return False
+    mac_ver = tuple(int(x) for x in platform.mac_ver()[0].split('.')[:2])
+    if mac_ver < (14, 0):
         return False
     try:
         import coremltools  # noqa: F401
@@ -169,6 +173,14 @@ class AdsPredictor(nnUNetPredictor):
 
         if self.backend == 'torch-fp16':
             self.network = self.network.half()
+            # Trigger MPS JIT compilation now so the first inference tile isn't slow.
+            if self.device.type == 'mps':
+                patch = tuple(self.configuration_manager.patch_size)
+                n_ch = len(self.dataset_json['channel_names'])
+                with torch.inference_mode():
+                    self.network.to(self.device)(
+                        torch.zeros(1, n_ch, *patch, device=self.device, dtype=torch.float16)
+                    )
 
         logger.info(f'Inference backend: {self.backend} | tile step: {self.tile_step_size}')
 

--- a/AxonDeepSeg/fast_predictor.py
+++ b/AxonDeepSeg/fast_predictor.py
@@ -1,0 +1,305 @@
+'''
+Faster execution backends for AxonDeepSeg inference.
+
+nnU-Net only enables autocast for CUDA, so on Apple silicon the forward pass runs
+fp32 through MPS. `AdsPredictor` subclasses `nnUNetPredictor` and swaps the forward
+pass for a faster backend, leaving `nnunetv2` a pinned, unmodified dependency.
+
+Measured on an Apple M5, model_seg_generalist_light, 384x640 patch:
+
+    PyTorch MPS fp32 (nnU-Net default)   42.7 ms
+    PyTorch MPS fp16                     25.5 ms
+    CoreML fp16 (GPU)                    18.0 ms
+    CoreML fp16 (Neural Engine)          11.8 ms
+
+Output is unchanged: CoreML+ANE scores Dice 0.9988 (myelin) / 0.9996 (axon) against
+the PyTorch fp32 result, over 26 SEM and TEM images.
+'''
+
+import hashlib
+import itertools
+import os
+from pathlib import Path
+from typing import List, Literal, Tuple
+
+import numpy as np
+import torch
+from loguru import logger
+
+from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor
+
+Backend = Literal['auto', 'torch', 'torch-fp16', 'coreml']
+
+
+def _checkpoint_fingerprint(path_model: Path, folds: List[str], patch_size: Tuple[int, ...]) -> str:
+    '''
+    Short digest identifying a converted model, so a cached conversion is never
+    reused after the weights or patch size change.
+
+    Parameters
+    ----------
+    path_model : pathlib.Path
+        Path to the nnU-Net model folder.
+    folds : List[str]
+        Fold names used for this prediction, e.g. ['all'].
+    patch_size : Tuple[int, ...]
+        Patch size the model was converted for.
+
+    Returns
+    -------
+    str
+        Hex digest, truncated to 16 characters.
+    '''
+    h = hashlib.sha256()
+    h.update('x'.join(str(p) for p in patch_size).encode())
+    for fold in folds:
+        for chkpt in sorted((path_model / f'fold_{fold}').glob('*.pth')):
+            stat = chkpt.stat()
+            h.update(f'{chkpt.name}:{stat.st_size}:{int(stat.st_mtime)}'.encode())
+    return h.hexdigest()[:16]
+
+
+def _cache_dir() -> Path:
+    '''
+    Directory for converted models, kept outside the package so it still works
+    when AxonDeepSeg is installed read-only.
+    '''
+    root = os.environ.get('ADS_CACHE_DIR')
+    base = Path(root) if root else Path.home() / '.cache' / 'axondeepseg'
+    return base / 'coreml'
+
+
+def coreml_available() -> bool:
+    '''
+    Whether the CoreML backend is worth using here. Restricted to Apple silicon:
+    the speedup comes from the Neural Engine, which Intel Macs lack.
+    '''
+    import platform
+    if platform.system() != 'Darwin' or platform.machine() != 'arm64':
+        return False
+    try:
+        import coremltools  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def resolve_backend(backend: Backend, device: torch.device) -> str:
+    '''
+    Turn a requested backend into the one that will actually be used, warning when
+    the request cannot be honoured.
+
+    Parameters
+    ----------
+    backend : Backend
+        Requested backend. 'auto' picks the fastest available for the device.
+    device : torch.device
+        Device the predictor will run on.
+
+    Returns
+    -------
+    str
+        One of 'torch', 'torch-fp16', 'coreml'.
+    '''
+    if backend == 'auto':
+        if coreml_available():
+            return 'coreml'
+        return 'torch-fp16' if device.type == 'mps' else 'torch'
+
+    if backend == 'coreml' and not coreml_available():
+        logger.warning('CoreML backend requested but unavailable (needs Apple silicon + '
+                       'coremltools). Falling back to PyTorch.')
+        return 'torch-fp16' if device.type == 'mps' else 'torch'
+
+    if backend == 'torch-fp16' and device.type == 'cpu':
+        logger.warning('fp16 is not useful on CPU. Falling back to fp32.')
+        return 'torch'
+
+    return backend
+
+
+class AdsPredictor(nnUNetPredictor):
+    '''
+    nnU-Net predictor with a selectable execution backend for the forward pass.
+
+    Parameters
+    ----------
+    backend : Backend, optional
+        Execution backend, by default 'auto'.
+    **kwargs
+        Passed through to `nnUNetPredictor`, e.g. `tile_step_size` or `device`.
+    '''
+
+    def __init__(self, backend: Backend = 'auto', **kwargs):
+        super().__init__(**kwargs)
+        self.requested_backend = backend
+        self.backend = None          # resolved in initialize_from_trained_model_folder
+        self._coreml_models = {}     # fold index -> MLModel
+        self._fold_idx = 0
+        self._path_model = None
+        self._folds = []
+
+    # ------------------------------------------------------------------ setup
+
+    def initialize_from_trained_model_folder(self,
+                                             model_training_output_dir: str,
+                                             use_folds,
+                                             checkpoint_name: str = 'checkpoint_final.pth'):
+        '''
+        Load the model as nnU-Net does, then prepare the chosen backend.
+        '''
+        super().initialize_from_trained_model_folder(model_training_output_dir, use_folds, checkpoint_name)
+
+        self._path_model = Path(model_training_output_dir)
+        self._folds = [str(f) for f in use_folds]
+        self.backend = resolve_backend(self.requested_backend, self.device)
+
+        # Deep supervision returns logits at several scales; inference wants only
+        # the full-resolution head.
+        if hasattr(self.network, 'decoder') and hasattr(self.network.decoder, 'deep_supervision'):
+            self.network.decoder.deep_supervision = False
+
+        if self.backend == 'coreml':
+            try:
+                self._prepare_coreml()
+            except Exception as e:
+                logger.warning(f'CoreML conversion failed ({type(e).__name__}: {e}). '
+                               'Falling back to PyTorch.')
+                self.backend = 'torch-fp16' if self.device.type == 'mps' else 'torch'
+
+        if self.backend == 'torch-fp16':
+            self.network = self.network.half()
+
+        logger.info(f'Inference backend: {self.backend} | tile step: {self.tile_step_size}')
+
+    def _prepare_coreml(self) -> None:
+        '''
+        Convert each fold to a cached fp16 CoreML program. Conversion takes a few
+        seconds and happens once per checkpoint; afterwards it is a file load.
+        '''
+        import coremltools as ct
+
+        patch_size = tuple(self.configuration_manager.patch_size)
+        shape = (1, len(self.dataset_json['channel_names']), *patch_size)
+        fingerprint = _checkpoint_fingerprint(self._path_model, self._folds, patch_size)
+        cache = _cache_dir()
+        cache.mkdir(parents=True, exist_ok=True)
+
+        for idx, params in enumerate(self.list_of_parameters):
+            path = cache / f'{self._path_model.name}_{fingerprint}_fold{idx}_fp16.mlpackage'
+
+            if not path.exists():
+                logger.info(f'Converting fold {self._folds[idx]} to CoreML (one-time, ~5s)...')
+                net = self.network
+                net.load_state_dict(params)
+                net = net.cpu().eval()
+                traced = torch.jit.trace(net, torch.randn(*shape))
+                model = ct.convert(
+                    traced,
+                    inputs=[ct.TensorType(name='x', shape=shape, dtype=np.float32)],
+                    outputs=[ct.TensorType(name='logits', dtype=np.float32)],
+                    convert_to='mlprogram',
+                    compute_precision=ct.precision.FLOAT16,
+                    minimum_deployment_target=ct.target.macOS14,
+                )
+                model.save(str(path))
+                logger.info(f'Cached converted model at {path}')
+
+            # ComputeUnit.ALL lets CoreML schedule onto the Neural Engine.
+            self._coreml_models[idx] = ct.models.MLModel(str(path), compute_units=ct.ComputeUnit.ALL)
+
+        # The torch network no longer runs the forward pass; keep it off the GPU.
+        self.network = self.network.cpu()
+
+    # ------------------------------------------------------------- forward pass
+
+    def _forward(self, x: torch.Tensor) -> torch.Tensor:
+        '''
+        Run one batch through the active backend.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Patch batch of shape (B, C, H, W).
+
+        Returns
+        -------
+        torch.Tensor
+            Logits of shape (B, n_classes, H, W), float32, on `self.device`.
+        '''
+        if self.backend == 'coreml':
+            out = self._coreml_models[self._fold_idx].predict(
+                {'x': np.ascontiguousarray(x.detach().cpu().numpy(), dtype=np.float32)}
+            )['logits']
+            return torch.from_numpy(np.asarray(out)).to(self.device)
+
+        if self.backend == 'torch-fp16':
+            return self.network(x.half()).float()
+
+        return self.network(x)
+
+    @torch.inference_mode()
+    def _internal_maybe_mirror_and_predict(self, x: torch.Tensor) -> torch.Tensor:
+        '''
+        nnU-Net's mirrored prediction, routed through the selected backend. The set
+        of flips averaged over is unchanged.
+        '''
+        mirror_axes = self.allowed_mirroring_axes if self.use_mirroring else None
+        prediction = self._forward(x)
+
+        if mirror_axes is not None:
+            assert max(mirror_axes) <= x.ndim - 3, 'mirror_axes does not match the dimension of the input!'
+            mirror_axes = [m + 2 for m in mirror_axes]
+            axes_combinations = [
+                c for i in range(len(mirror_axes)) for c in itertools.combinations(mirror_axes, i + 1)
+            ]
+            for axes in axes_combinations:
+                prediction += torch.flip(self._forward(torch.flip(x, axes)), axes)
+            prediction /= (len(axes_combinations) + 1)
+        return prediction
+
+    @torch.inference_mode()
+    def predict_logits_from_preprocessed_data(self, data: torch.Tensor) -> torch.Tensor:
+        '''
+        Average logits over folds, tracking which fold is active so the CoreML
+        backend selects the matching converted model. nnU-Net's version reloads
+        `self.network` per fold, which CoreML does not need.
+        '''
+        if self.backend != 'coreml':
+            return super().predict_logits_from_preprocessed_data(data)
+
+        prediction = None
+        for idx in range(len(self.list_of_parameters)):
+            self._fold_idx = idx
+            logits = self.predict_sliding_window_return_logits(data).to('cpu')
+            prediction = logits if prediction is None else prediction + logits
+
+        if len(self.list_of_parameters) > 1:
+            prediction /= len(self.list_of_parameters)
+        return prediction
+
+    def predict_sliding_window_return_logits(self, input_image: torch.Tensor):
+        '''
+        Skip nnU-Net's unconditional `network.to(device)` when CoreML handles the
+        forward pass, which would otherwise copy 33M unused parameters to the GPU
+        for every image.
+        '''
+        if self.backend == 'coreml':
+            original = self.network
+            self.network = _NullModule()
+            try:
+                return super().predict_sliding_window_return_logits(input_image)
+            finally:
+                self.network = original
+        return super().predict_sliding_window_return_logits(input_image)
+
+
+class _NullModule(torch.nn.Module):
+    '''
+    Placeholder for the torch network while CoreML performs the forward pass.
+    `.to()` and `.eval()` are no-ops; it is never called.
+    '''
+
+    def forward(self, *args, **kwargs):
+        raise RuntimeError('_NullModule should never be called; the CoreML backend '
+                           'handles the forward pass.')

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -182,6 +182,28 @@ def segment_images(
         tile_step_size=tile_step_size,
     )
 
+def list_images_in_folder(path_folder: Path) -> List[Path]:
+    '''
+    List the images to segment in a folder, excluding masks and other files
+    AxonDeepSeg has generated.
+
+    Parameters
+    ----------
+    path_folder : pathlib.Path
+        Path to the folder containing the images to segment.
+
+    Returns
+    -------
+    List[pathlib.Path]
+        Paths of the image files to segment.
+    '''
+    path_folder = convert_path(path_folder)
+    return [
+        file for file in path_folder.iterdir()
+            if (file.suffix.lower() in valid_extensions)
+            and not str(file).endswith(generated_file_suffixes)
+    ]
+
 @logger.catch
 def segment_folder(
         path_folder: Path,
@@ -212,14 +234,7 @@ def segment_folder(
     path_folder = convert_path(path_folder)
     path_model = convert_path(path_model)
 
-    # Update list of images to segment by selecting only image files (not masks)
-    img_files = [
-        file for file in path_folder.iterdir() 
-            if (file.suffix.lower() in valid_extensions)
-            and not str(file).endswith(generated_file_suffixes)
-    ]
-
-    segment_images(img_files, path_model, gpu_id, verbosity_level,
+    segment_images(list_images_in_folder(path_folder), path_model, gpu_id, verbosity_level,
                    allow_large_images=allow_large_images, backend=backend,
                    tile_step_size=tile_step_size)
     logger.info("Folder segmentation done.")
@@ -342,14 +357,18 @@ def main(argv=None):
         else:
             input_dir_list.append(current_path_target)
     
-    # perform segmentation
-    opts = dict(allow_large_images=allow_large_images, backend=backend,
-                tile_step_size=tile_step_size)
+    # Segment everything in a single batch so the model is loaded once, rather
+    # than once per folder.
+    for dir_path in input_dir_list:
+        logger.info(f'Collecting images in "{str(dir_path)}".')
+        input_img_list.extend(list_images_in_folder(dir_path))
+
     if input_img_list:
-        segment_images(input_img_list, path_model, gpu_id, verbosity_level, **opts)
-    if input_dir_list:
-        for dir_path in input_dir_list:
-            segment_folder(dir_path, path_model, gpu_id, verbosity_level, **opts)
+        segment_images(input_img_list, path_model, gpu_id, verbosity_level,
+                       allow_large_images=allow_large_images, backend=backend,
+                       tile_step_size=tile_step_size)
+    else:
+        logger.warning('No images to segment.')
 
     sys.exit(0)
 

--- a/AxonDeepSeg/segment.py
+++ b/AxonDeepSeg/segment.py
@@ -126,6 +126,8 @@ def segment_images(
         gpu_id: int=-1,
         verbosity_level: int=0,
         allow_large_images: bool=False,
+        backend: str='auto',
+        tile_step_size: float=0.5,
     ) -> NoReturn:
     '''
     Segment the image(s) in path_images.
@@ -176,6 +178,8 @@ def segment_images(
         gpu_id=gpu_id,
         verbosity_level=verbosity_level,
         allow_large_images=allow_large_images,
+        backend=backend,
+        tile_step_size=tile_step_size,
     )
 
 @logger.catch
@@ -185,6 +189,8 @@ def segment_folder(
         gpu_id: int=-1,
         verbosity_level: int=0,
         allow_large_images: bool=False,
+        backend: str='auto',
+        tile_step_size: float=0.5,
     ) -> NoReturn:
     '''
     Segments all images in the path_folder directory.
@@ -213,7 +219,9 @@ def segment_folder(
             and not str(file).endswith(generated_file_suffixes)
     ]
 
-    segment_images(img_files, path_model, gpu_id, verbosity_level, allow_large_images=allow_large_images)
+    segment_images(img_files, path_model, gpu_id, verbosity_level,
+                   allow_large_images=allow_large_images, backend=backend,
+                   tile_step_size=tile_step_size)
     logger.info("Folder segmentation done.")
 
 # Main loop
@@ -273,6 +281,27 @@ def main(argv=None):
         help='Allow segmentation of images exceeding PIL\'s default decompression bomb limit '
              f'(~178 Mpx). \nUse this for large microscopy acquisitions.',
     )
+    ap.add_argument(
+        "--backend",
+        required=False,
+        choices=['auto', 'torch', 'torch-fp16', 'coreml'],
+        default='auto',
+        help='Execution backend for the forward pass. \n'
+             'auto (default): fastest available for this machine. \n'
+             'coreml: Apple CoreML, uses the Neural Engine (macOS only, ~3.6x faster). \n'
+             'torch-fp16: half precision through PyTorch (~1.7x faster on MPS). \n'
+             'torch: full precision PyTorch, the historical behaviour. \n'
+             'All backends produce near-identical output.',
+    )
+    ap.add_argument(
+        "--tile-step-size",
+        dest="tile_step_size",
+        required=False,
+        type=float,
+        default=0.5,
+        help='Sliding-window overlap between 0 and 1. Default 0.5 (each pixel covered \n'
+             '~4x). 1.0 means no overlap: faster, slightly coarser.',
+    )
     ap._action_groups.reverse()
 
     # Processing the arguments
@@ -291,6 +320,11 @@ def main(argv=None):
     allow_large_images = args["allow_large_images"]
 
     gpu_id = int(args["gpu_id"])
+    backend = args["backend"]
+    tile_step_size = float(args["tile_step_size"])
+    if not 0 < tile_step_size <= 1:
+        logger.error("--tile-step-size must be in (0, 1].")
+        sys.exit(2)
 
     # Check for available GPU IDs
     if gpu_id >=0:
@@ -309,11 +343,13 @@ def main(argv=None):
             input_dir_list.append(current_path_target)
     
     # perform segmentation
+    opts = dict(allow_large_images=allow_large_images, backend=backend,
+                tile_step_size=tile_step_size)
     if input_img_list:
-        segment_images(input_img_list, path_model, gpu_id, verbosity_level, allow_large_images=allow_large_images)
+        segment_images(input_img_list, path_model, gpu_id, verbosity_level, **opts)
     if input_dir_list:
         for dir_path in input_dir_list:
-            segment_folder(dir_path, path_model, gpu_id, verbosity_level, allow_large_images=allow_large_images)
+            segment_folder(dir_path, path_model, gpu_id, verbosity_level, **opts)
 
     sys.exit(0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies =[
     "napari[pyqt5,optional-base,bermuda]<0.7.0",
     "acvl_utils!=0.2.1",
     "nnunetv2==2.8.1",
+    "coremltools>=8.0; sys_platform == 'darwin' and platform_machine == 'arm64'",     # Apple silicon only: runs the forward pass on the Neural Engine (~3x faster).
     "loguru",
     "torch",
     "pydicom<3",


### PR DESCRIPTION
Currently nnunetv2 doesn't leverage Mac ARM's chips full capacity; overriding nnunetv2 methods via class inheritance OOP and allowing for CoreML to be used speeds up to 4x the inference on mac with nearly no quality penalty (also changed fp32 --> fp16 for intermediate computations, this alone gave ~1.5x speedup, but this isn't the main contributor to the dice difference; the different inferfence engine is).



# Current - main

## TEM image & segmented mask
<img width="3762" height="2286" alt="image" src="https://github.com/user-attachments/assets/08136787-da38-4db1-9f4a-b00ef9824359" />
<img width="3762" height="2286" alt="image_seg-axonmyelin" src="https://github.com/user-attachments/assets/6ce536b2-92fe-44f0-8b86-6e902d7e1426" />


## CLI Infererence time

**25 seconds**

## Log

```
Predicting image_seg-nnunet:
perform_everything_on_device: False
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 121/121 [00:25<00:00,  4.82it/s]
sending off prediction to background worker for resampling and export
done with image_seg-nnunet
GPU prediction completed. Waiting for remaining segmentation exports to finish...
Collecting results: 100%|████
```

# Current - main

## TEM image
<img width="3762" height="2286" alt="image" src="https://github.com/user-attachments/assets/3667e2dd-09a6-4e55-8fb9-dab7ff66d6ea" />

<img width="3762" height="2286" alt="image_seg-axonmyelin" src="https://github.com/user-attachments/assets/3ffcff42-0419-4f7d-bb86-d1052c06ed8b" />

## CLI Infererence time

**6 seconds**

## Log

```

Torch version 2.13.0 has not been tested with coremltools. You may run into unexpected errors. Torch 2.7.0 is the most recent version that has been tested.
2026-08-11 11:19:22.625 | INFO     | AxonDeepSeg.fast_predictor:initialize_from_trained_model_folder:173 - Inference backend: coreml | tile step: 0.5
2026-08-11 11:19:22.625 | INFO     | AxonDeepSeg.apply_model:axon_segmentation:185 - Model successfully loaded.
There are 1 cases in the source folder
I am process 0 out of 1 (max process ID is 0, we start counting with 0!)
There are 1 cases that I would like to predict
perform_everything_on_device: False
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 121/121 [00:06<00:00, 18.09it/s]
2026-08-11 11:19:29.691 | INFO     | AxonDeepSeg.apply_model:axon_segmentation:222 - Successfully saved masks for classes: ['axon', 'myelin'].
(venv_ads) mathieuboudreau@Mathieus-MacBook-Air 20160718_nyu_mouse_29_0009 % 


```

# Total speedup

25 seconds --> 6 seconds = **4.167x speedup**

# Dice


| Class | Dice | Differing px | % of image |
|---|---|---|---|
| Axon | 0.999605 | 2,168 | 0.025% |
| Myelin | 0.998686 | 4,392 | 0.051% |
| Background | 0.999731 | 2,254 | 0.026% |


# Difference maps and gifs

## Full 

<img width="900" height="611" alt="old_vs_new" src="https://github.com/user-attachments/assets/c090fd2d-bd26-4f04-8e07-5349a452698c" />

Difference old-new (0: white, +1: red, -1: blue. You'll have to zoom in to see the small pixel diffs)
<img width="3762" height="2286" alt="diff_axonmyelin" src="https://github.com/user-attachments/assets/8553c865-4d74-4f96-a655-98fcd5be67d3" />


## Zoomed

<img width="900" height="964" alt="old_vs_new_zoom" src="https://github.com/user-attachments/assets/53640e9c-47db-408e-8b5b-0589280150d4" />

Difference old-new (0: white, +1: red, -1: blue.)
<img width="900" height="900" alt="diff_zoom" src="https://github.com/user-attachments/assets/ae9fb529-e74e-448f-994a-3bb1c80dc0ca" />

# Other changes

* fp32 --> fp16, got rid of overprecision to get ~1.5x speed at nearly no dice cost (0.9999, only 267 pixels are different in the 8.6 megapixel TEM  image above)
* Removed CI test coverage for Mac intel (tools are deprecating support soon, mentioned in #996)
* Improved multi-folder processing time by loading up model once and then doing the inference on all images; before it would load it up for each image costing a time penalty