### PR TITLE
Fix pipy CI on Windows + Mac OS 3.12 runner

### DIFF
--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -106,5 +106,5 @@ jobs:
         with:
           python-version: '3.x'
       - name: Pypi install test finished
-        run: echo "Tests comlete!"
+        run: echo "Tests complete!"
 

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -83,6 +83,8 @@ jobs:
       - name: Test with pytest
         timeout-minutes: 20
         shell: bash
+        env:
+          PYTHONFAULTHANDLER: '1'
         run: |
           git pull --all
           git checkout "$(git tag --sort=-v:refname | head -1)"
@@ -94,14 +96,14 @@ jobs:
           python -c "import AxonDeepSeg.download_model as download_model; download_model.main(['-d', './AxonDeepSeg/models'])"
 
           set +e
-          python - <<'PY'
-          import faulthandler, sys, pytest
-          faulthandler.dump_traceback_later(720, exit=True)
-          sys.exit(pytest.main(["./", "-v"]))
-          PY
+          pytest ./ -v &
+          PYTEST_PID=$!
+          ( sleep 900; kill -ABRT $PYTEST_PID ) >/dev/null 2>&1 &
+          WATCHDOG_PID=$!
+          wait $PYTEST_PID
           status=$?
+          kill $WATCHDOG_PID 2>/dev/null
           set -e
-          pkill -f torch_shm_manager 2>/dev/null || true
           exit $status
 
   # This step is MANDATORY and used to indicate matrix completion to coveralls.io

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -39,7 +39,8 @@ jobs:
 
     # Matrix driven OS
     runs-on: ${{ matrix.os }}
-
+    timeout-minutes: 30
+  
     # Defining matrix for OS and Python
     strategy:
       fail-fast: false

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -93,7 +93,12 @@ jobs:
           python -c "import AxonDeepSeg.download_model as download_model; download_model.main()"
           python -c "import AxonDeepSeg.download_model as download_model; download_model.main(['-d', './AxonDeepSeg/models'])"
 
+          set +e
           pytest ./ -v
+          status=$?
+          set -e
+          pkill -f torch_shm_manager 2>/dev/null || true
+          exit $status
 
   # This step is MANDATORY and used to indicate matrix completion to coveralls.io
   # See here: https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -96,6 +96,10 @@ jobs:
         shell: cmd
         run: |
 
+          git pull --all
+
+          git checkout $( git tag | tail -1)
+
           rmdir ./AxonDeepSeg/
 
           python -c "import AxonDeepSeg.download_tests as download_tests; download_tests.main()"

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -94,7 +94,11 @@ jobs:
           python -c "import AxonDeepSeg.download_model as download_model; download_model.main(['-d', './AxonDeepSeg/models'])"
 
           set +e
-          pytest ./ -v
+          python - <<'PY'
+          import faulthandler, sys, pytest
+          faulthandler.dump_traceback_later(720, exit=True)
+          sys.exit(pytest.main(["./", "-v"]))
+          PY
           status=$?
           set -e
           pkill -f torch_shm_manager 2>/dev/null || true

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -57,19 +57,27 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Step 2: Install environment.
+      # Step 2a: Install environment.
       - name: Install Latest pypi version of AxonDeepSeg
         run: |
           pip install --upgrade pip
           pip install axondeepseg==5.5.0 --no-cache-dir
 
 
-      # Step 2a: Modify MKL_THREADING_LAYER (Ubuntu only)
+      # Step 2b: Modify MKL_THREADING_LAYER (Ubuntu only)
       # See https://github.com/pytorch/pytorch/issues/37377#issuecomment-629530272
       - name: Set MKL_THREADING_LAYER
         if: matrix.os == 'ubuntu-latest'
         run: |
           echo "MKL_THREADING_LAYER=GNU" >> $GITHUB_ENV
+
+      # Step 2c: Virtual display so Qt/napari GUI tests can run on Linux
+      - name: Set up headless display (Linux)
+        if: runner.os == 'Linux'
+        uses: pyvista/setup-headless-display-action@v4
+        with:
+          qt: true
+          pyvista: false
 
       # Step 3: Full PyTest
       - name: Test with pytest (Unix)

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -13,6 +13,7 @@ on:
     branches:
       - master
       - 'release/**'
+      - mb/pipywindows
 
   # Trigger current workflow on PR from ANY branch
   pull_request:

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -89,6 +89,7 @@ jobs:
           git pull --all
           git checkout "$(git tag --sort=-v:refname | head -1)"
           rm -rf ./AxonDeepSeg/
+          printf 'import multiprocessing.resource_tracker as _rt\nif hasattr(_rt.ResourceTracker, "__del__"):\n    del _rt.ResourceTracker.__del__\n' > conftest.py
 
           python -c "import AxonDeepSeg.download_tests as download_tests; download_tests.main()"
           python -c "import AxonDeepSeg.download_tests as download_tests; download_tests.main(['-d', './test/'])"

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -13,7 +13,6 @@ on:
     branches:
       - master
       - 'release/**'
-      - mb/pipywindows
 
   # Trigger current workflow on PR from ANY branch
   pull_request:

--- a/.github/workflows/pipy_install_tests.yaml
+++ b/.github/workflows/pipy_install_tests.yaml
@@ -80,14 +80,12 @@ jobs:
           pyvista: false
 
       # Step 3: Full PyTest
-      - name: Test with pytest (Unix)
-        if: ${{ (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest' && matrix.python-version == '3.11') || (matrix.os == 'macos-26-intel' && matrix.python-version == '3.11') }}
+      - name: Test with pytest
+        timeout-minutes: 20
+        shell: bash
         run: |
-
           git pull --all
-
-          git checkout $( git tag | tail -1)
-
+          git checkout "$(git tag --sort=-v:refname | head -1)"
           rm -rf ./AxonDeepSeg/
 
           python -c "import AxonDeepSeg.download_tests as download_tests; download_tests.main()"
@@ -96,29 +94,6 @@ jobs:
           python -c "import AxonDeepSeg.download_model as download_model; download_model.main(['-d', './AxonDeepSeg/models'])"
 
           pytest ./ -v
-          echo "All done!"
-          exit 0 
-          
-    
-
-      - name: Test with pytest (Windows)
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-
-          git pull --all
-
-          git checkout $( git tag | tail -1)
-
-          rmdir ./AxonDeepSeg/
-
-          python -c "import AxonDeepSeg.download_tests as download_tests; download_tests.main()"
-          python -c "import AxonDeepSeg.download_tests as download_tests; download_tests.main(['-d', './test/'])"
-          python -c "import AxonDeepSeg.download_model as download_model; download_model.main()"
-          python -c "import AxonDeepSeg.download_model as download_model; download_model.main(['-d', './AxonDeepSeg/models'])"
-
-          pytest.exe ./ -v
-
 
   # This step is MANDATORY and used to indicate matrix completion to coveralls.io
   # See here: https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - master
-      - mb/pipywindows
 
   # Trigger current workflow on PR from ANY branch
   pull_request:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -95,6 +95,14 @@ jobs:
             cat ~/.bashrc | grep "export PATH" | grep -o "/.*" | cut -d ':' -f 1 >> $GITHUB_PATH
           fi
 
+      # Step 2c: Virtual display so Qt/napari GUI tests can run on Linux
+      - name: Set up headless display (Linux)
+        if: runner.os == 'Linux'
+        uses: pyvista/setup-headless-display-action@v4
+        with:
+          qt: true
+          pyvista: false
+
       # Step 3: Full PyTest
       - name: Test with pytest (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -39,6 +39,7 @@ jobs:
 
     # Matrix driven OS
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
 
     # Default shell for ALL subsequent steps.
     defaults:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - master
+      - mb/pipywindows
 
   # Trigger current workflow on PR from ANY branch
   pull_request:


### PR DESCRIPTION
Nightly build have been failing - this fixes two issues; 1) the windows builds that were failing when ADS was installed via pipy, and 2) the Mac OS 3.12 runner that we were previously skipping due to a separate issue.