### PR TITLE
Morphometrics filtering + Axon counting

### DIFF
--- a/AxonDeepSeg/apply_model.py
+++ b/AxonDeepSeg/apply_model.py
@@ -209,7 +209,7 @@ def axon_segmentation(
     output_structure = predictor.dataset_json['labels']
     output_classes = sorted(list(output_structure.keys()))
     output_classes.remove('background')
-    is_axonmyelin_seg = ['axon', 'myelin'] == output_classes
+    has_axonmyelin_seg = {'axon', 'myelin'} <= set(output_classes)
 
     # nnUNet outputs a single file will all classes mapped to consecutive ints
     for pred_path in output_list:
@@ -223,7 +223,7 @@ def axon_segmentation(
             new_masks.append(new_fname)
         logger.info(f'Successfully saved masks for classes: {output_classes}.')
 
-        if is_axonmyelin_seg:
+        if has_axonmyelin_seg:
             merge_masks(new_masks[0], new_masks[1])
 
         Path(fname).unlink()

--- a/AxonDeepSeg/morphometrics/count_axons.py
+++ b/AxonDeepSeg/morphometrics/count_axons.py
@@ -1,0 +1,114 @@
+'''
+Finds all morphometric files in a folder and counts the number of axons (myelinated and unmyelinated, 
+if applicable) in each file. The results are saved to a CSV file.
+'''
+from pathlib import Path
+from tqdm import tqdm
+import argparse
+from loguru import logger
+
+import pandas as pd
+from skimage import measure
+
+from AxonDeepSeg.ads_utils import imread
+from AxonDeepSeg.params import generated_file_suffixes
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Count axons (myelinated and unmyelinated, if applicable).')
+    parser.add_argument(
+        '-i',
+        dest='input_dir',
+        type=str,
+        help='Path to the folder containing all morphometric files.'
+    )
+    parser.add_argument(
+        '-m', '--mask_mode',
+        action='store_true',
+        default=False,
+        help='Toggles mask mode: use masks instead of .xlsx to count axons.'
+    )
+    parser.add_argument(
+        '-o',
+        dest='output_name',
+        type=str,
+        default='axon_counts.csv',
+        help='Name of the output file.',
+    )
+
+    args = parser.parse_args()
+    input_dir = Path(args.input_dir)
+    out_name = args.output_name
+    mask_mode = args.mask_mode
+    assert input_dir.exists(), f'Directory {input_dir} does not exist.'
+
+    # find images except for the masks
+    additional_suffixes = [
+        '_seg-axonmyelin_filtered.png', '_seg-uaxon_filtered.png', 
+        '_seg-axon_filtered.png', '_seg-myelin_filtered.png',
+        '_seg-nuclei.png', '_seg-process.png', 
+    ]
+    ignore_suffixes = [str(s) for s in generated_file_suffixes if str(s).endswith('.png')] + additional_suffixes
+    ignore_suffixes = tuple(ignore_suffixes)
+    inputs = [f for f in input_dir.glob('*.png') if not f.name.endswith(ignore_suffixes)]
+
+    counts = {'image': [], 'axon_count': [], 'uaxon_count': []}
+    axon_morph_suffix = '_axon_morphometrics.xlsx'
+    uaxon_morph_suffix = '_uaxon_morphometrics.xlsx'
+
+    total_axon_count = 0
+    total_uaxon_count = 0
+    total_size = 0
+    for img in tqdm(inputs):
+        if not mask_mode:
+            # read morphometric files
+            target_axon_file = str(img.with_suffix('')) + axon_morph_suffix
+            target_uaxon_file = str(img.with_suffix('')) + uaxon_morph_suffix
+            # filtered morphometrics take precedence over unfiltered morphometrics
+            filtered_axon_file = str(img.with_suffix('')) + '_axon_morphometrics_filtered.xlsx'
+            filtered_uaxon_file = str(img.with_suffix('')) + '_uaxon_morphometrics_filtered.xlsx'
+            if Path(filtered_axon_file).exists():
+                target_axon_file = filtered_axon_file
+            if Path(filtered_uaxon_file).exists():
+                target_uaxon_file = filtered_uaxon_file
+
+            axon_count = len(pd.read_excel(target_axon_file))
+            uaxon_count = len(pd.read_excel(target_uaxon_file))
+        else:
+            target_axonmyelin_mask = str(img.with_suffix('')) + '_seg-axonmyelin.png'
+            target_uaxon_mask = str(img.with_suffix('')) + '_seg-uaxon.png'
+            filtered_axonmyelin_mask = str(img.with_suffix('')) + '_seg-axonmyelin_filtered.png'
+            filtered_uaxon_mask = str(img.with_suffix('')) + '_seg-uaxon_filtered.png'
+            if Path(filtered_axonmyelin_mask).exists():
+                target_axonmyelin_mask = filtered_axonmyelin_mask
+            if Path(filtered_uaxon_mask).exists():
+                target_uaxon_mask = filtered_uaxon_mask
+
+            axonmyelin = imread(target_axonmyelin_mask) > 200
+            uaxon = imread(target_uaxon_mask) > 200
+            total_size += axonmyelin.shape[0] * axonmyelin.shape[1]
+
+            # count axons
+            axon_objects = measure.regionprops(measure.label(axonmyelin))
+            uaxon_objects = measure.regionprops(measure.label(uaxon))
+            axon_count = len(axon_objects)
+            uaxon_count = len(uaxon_objects)
+
+        # add data
+        counts['image'].append(img.stem)
+        counts['axon_count'].append(axon_count)
+        counts['uaxon_count'].append(uaxon_count)
+        total_axon_count += axon_count
+        total_uaxon_count += uaxon_count
+
+    # save counts
+    df = pd.DataFrame(counts)
+    df.to_csv(out_name, index=False)
+    logger.info(f'Total myelinated axon count: {total_axon_count}. Total unmyelinated axon count: {total_uaxon_count}')
+    if mask_mode:
+        logger.info(f'Total area covered is {total_size} pixels.')
+
+    
+if __name__ == "__main__":
+    with logger.catch():
+        main()

--- a/AxonDeepSeg/morphometrics/count_axons.py
+++ b/AxonDeepSeg/morphometrics/count_axons.py
@@ -14,7 +14,7 @@ from AxonDeepSeg.ads_utils import imread
 from AxonDeepSeg.params import generated_file_suffixes
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(description='Count axons (myelinated and unmyelinated, if applicable).')
     parser.add_argument(
         '-i',
@@ -36,7 +36,7 @@ def main():
         help='Name of the output file.',
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     input_dir = Path(args.input_dir)
     out_name = args.output_name
     mask_mode = args.mask_mode

--- a/AxonDeepSeg/morphometrics/count_axons.py
+++ b/AxonDeepSeg/morphometrics/count_axons.py
@@ -11,7 +11,7 @@ import pandas as pd
 from skimage import measure
 
 from AxonDeepSeg.ads_utils import imread
-from AxonDeepSeg.params import generated_file_suffixes
+from AxonDeepSeg.params import generated_file_suffixes, valid_extensions
 
 
 def main(argv=None):
@@ -50,10 +50,14 @@ def main(argv=None):
     ]
     ignore_suffixes = [str(s) for s in generated_file_suffixes if str(s).endswith('.png')] + additional_suffixes
     ignore_suffixes = tuple(ignore_suffixes)
+    is_valid_input = lambda path: (
+        path.suffix.lower() in valid_extensions
+        and not path.name.endswith(ignore_suffixes)
+    )
     if input_path.is_file():
-        inputs = [input_path] if not input_path.name.endswith(ignore_suffixes) else []
+        inputs = [input_path] if is_valid_input(input_path) else []
     else:
-        inputs = [f for f in input_path.glob('*.png') if not f.name.endswith(ignore_suffixes)]
+        inputs = [path for path in input_path.glob('*') if is_valid_input(path)]
 
     counts = {'image': [], 'axon_count': [], 'uaxon_count': []}
     axon_morph_suffix = '_axon_morphometrics.xlsx'

--- a/AxonDeepSeg/morphometrics/count_axons.py
+++ b/AxonDeepSeg/morphometrics/count_axons.py
@@ -20,7 +20,7 @@ def main(argv=None):
         '-i',
         dest='input_dir',
         type=str,
-        help='Path to the folder containing all morphometric files.'
+        help='Path to the folder containing all morphometric files (or the folder containing all segmentations if mask mode is enabled).'
     )
     parser.add_argument(
         '-m', '--mask_mode',

--- a/AxonDeepSeg/morphometrics/count_axons.py
+++ b/AxonDeepSeg/morphometrics/count_axons.py
@@ -35,11 +35,21 @@ def main(argv=None):
         default='axon_counts.csv',
         help='Name of the output file.',
     )
+    parser.add_argument(
+        "--allow-large-images",
+        dest="allow_large_images",
+        required=False,
+        action='store_true',
+        default=False,
+        help='Allow counting axons on masks exceeding PIL\'s default decompression bomb limit '
+             f'(~89 Mpx). \nUse this for large microscopy acquisitions.',
+    )
 
     args = parser.parse_args(argv)
     input_path = Path(args.input_dir)
     out_name = args.output_name
     mask_mode = args.mask_mode
+    allow_large_images = args.allow_large_images
     assert input_path.exists(), f'Input path {input_path} does not exist.'
 
     # find images except for the masks
@@ -95,13 +105,13 @@ def main(argv=None):
             if Path(filtered_uaxon_mask).exists():
                 target_uaxon_mask = filtered_uaxon_mask
 
-            axonmyelin = imread(target_axonmyelin_mask) > 200
+            axonmyelin = imread(target_axonmyelin_mask, allow_large_images=allow_large_images) > 200
             total_size += axonmyelin.shape[0] * axonmyelin.shape[1]
             axon_objects = measure.regionprops(measure.label(axonmyelin))
             axon_count = len(axon_objects)
 
             if Path(target_uaxon_mask).exists():
-                uaxon = imread(target_uaxon_mask) > 200
+                uaxon = imread(target_uaxon_mask, allow_large_images=allow_large_images) > 200
                 uaxon_objects = measure.regionprops(measure.label(uaxon))
                 uaxon_count = len(uaxon_objects)
             else:

--- a/AxonDeepSeg/morphometrics/count_axons.py
+++ b/AxonDeepSeg/morphometrics/count_axons.py
@@ -76,7 +76,11 @@ def main(argv=None):
                 target_uaxon_file = filtered_uaxon_file
 
             axon_count = len(pd.read_excel(target_axon_file))
-            uaxon_count = len(pd.read_excel(target_uaxon_file))
+            if Path(target_uaxon_file).exists():
+                uaxon_count = len(pd.read_excel(target_uaxon_file))
+            else:
+                logger.info(f'No unmyelinated morphometrics file found for {img.stem}. Setting uaxon_count to 0.')
+                uaxon_count = 0
         else:
             target_axonmyelin_mask = str(img.with_suffix('')) + '_seg-axonmyelin.png'
             target_uaxon_mask = str(img.with_suffix('')) + '_seg-uaxon.png'
@@ -88,14 +92,17 @@ def main(argv=None):
                 target_uaxon_mask = filtered_uaxon_mask
 
             axonmyelin = imread(target_axonmyelin_mask) > 200
-            uaxon = imread(target_uaxon_mask) > 200
             total_size += axonmyelin.shape[0] * axonmyelin.shape[1]
-
-            # count axons
             axon_objects = measure.regionprops(measure.label(axonmyelin))
-            uaxon_objects = measure.regionprops(measure.label(uaxon))
             axon_count = len(axon_objects)
-            uaxon_count = len(uaxon_objects)
+
+            if Path(target_uaxon_mask).exists():
+                uaxon = imread(target_uaxon_mask) > 200
+                uaxon_objects = measure.regionprops(measure.label(uaxon))
+                uaxon_count = len(uaxon_objects)
+            else:
+                logger.info(f'No unmyelinated mask found for {img.stem}. Setting uaxon_count to 0.')
+                uaxon_count = 0
 
         # add data
         counts['image'].append(img.stem)

--- a/AxonDeepSeg/morphometrics/count_axons.py
+++ b/AxonDeepSeg/morphometrics/count_axons.py
@@ -37,10 +37,10 @@ def main(argv=None):
     )
 
     args = parser.parse_args(argv)
-    input_dir = Path(args.input_dir)
+    input_path = Path(args.input_dir)
     out_name = args.output_name
     mask_mode = args.mask_mode
-    assert input_dir.exists(), f'Directory {input_dir} does not exist.'
+    assert input_path.exists(), f'Input path {input_path} does not exist.'
 
     # find images except for the masks
     additional_suffixes = [
@@ -50,7 +50,10 @@ def main(argv=None):
     ]
     ignore_suffixes = [str(s) for s in generated_file_suffixes if str(s).endswith('.png')] + additional_suffixes
     ignore_suffixes = tuple(ignore_suffixes)
-    inputs = [f for f in input_dir.glob('*.png') if not f.name.endswith(ignore_suffixes)]
+    if input_path.is_file():
+        inputs = [input_path] if not input_path.name.endswith(ignore_suffixes) else []
+    else:
+        inputs = [f for f in input_path.glob('*.png') if not f.name.endswith(ignore_suffixes)]
 
     counts = {'image': [], 'axon_count': [], 'uaxon_count': []}
     axon_morph_suffix = '_axon_morphometrics.xlsx'

--- a/AxonDeepSeg/morphometrics/filter.yaml
+++ b/AxonDeepSeg/morphometrics/filter.yaml
@@ -1,0 +1,8 @@
+myelinated-rules:
+  - valid-g-ratio-only: True
+  - axon-diam-gt: ~
+
+unmyelinated-rules:
+  - axon-diam-gt: ~
+  - solidity-gt: ~
+  - axon-area-lt: ~

--- a/AxonDeepSeg/morphometrics/filter.yaml
+++ b/AxonDeepSeg/morphometrics/filter.yaml
@@ -1,8 +1,8 @@
-myelinated-rules:
+myelinated:
   - valid-g-ratio-only: True
   - axon-diam-gt: ~
 
-unmyelinated-rules:
+unmyelinated:
   - axon-diam-gt: ~
   - solidity-gt: ~
   - axon-area-lt: ~

--- a/AxonDeepSeg/morphometrics/filter_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/filter_morphometrics.py
@@ -34,8 +34,8 @@ def read_config(config_path: Path) -> dict:
     with open(str(config_path), 'r') as f:
         config = yaml.safe_load(f)
 
-    if config.keys() != {'myelinated-rules', 'unmyelinated-rules'}:
-        raise ValueError(f'Configuration file {config_path} must contain "myelinated-rules" and "unmyelinated-rules" keys.')
+    if config.keys() != {'myelinated', 'unmyelinated'}:
+        raise ValueError(f'Configuration file {config_path} must contain "myelinated" and "unmyelinated" keys.')
     
     return config
 
@@ -75,7 +75,7 @@ def process_morphometric_files(morpho_files, rules, axon_type, overwrite, apply_
 
         # artifact from xlsx import, remove the first column title if required
         df = df.rename(columns={'Unnamed: 0': ''})
-        
+
         if overwrite:
             df.to_excel(morpho_file, index=False)
             logger.info(f'Overwrote original file: {morpho_file}')
@@ -125,14 +125,14 @@ def main():
 
     process_morphometric_files(
         axon_morpho_files,
-        rules['myelinated-rules'],
+        rules['myelinated'],
         'myelinated',
         args.overwrite,
         apply_myelinated_rules,
     )
     process_morphometric_files(
         uaxon_morpho_files,
-        rules['unmyelinated-rules'],
+        rules['unmyelinated'],
         'unmyelinated',
         args.overwrite,
         apply_unmyelinated_rules,

--- a/AxonDeepSeg/morphometrics/filter_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/filter_morphometrics.py
@@ -11,6 +11,12 @@ from loguru import logger
 
 import pandas as pd
 import yaml
+import numpy as np
+from skimage import measure
+
+from AxonDeepSeg.ads_utils import imread, imwrite
+from AxonDeepSeg.morphometrics.compute_morphometrics import get_watershed_segmentation
+from AxonDeepSeg.visualization.merge_masks import merge_masks
 
 
 def read_config(config_path: Path) -> dict:
@@ -64,11 +70,111 @@ def apply_unmyelinated_rules(df, rules):
                 logger.warning(f'Unknown rule: {rule}')
     return df
 
-def process_morphometric_files(morpho_files, rules, axon_type, overwrite, apply_rules_fn):
+def mask_updater(morpho_file, axon_type, filtered_df, overwrite):
+    """
+    Update the segmentation masks to reflect the filtered morphometrics.
+
+    Parameters
+    ----------
+    morpho_file : pathlib.Path
+        Path to the morphometric file.
+    axon_type : str
+        Type of axon ('myelinated' or 'unmyelinated').
+    filtered_df : pandas.DataFrame
+        DataFrame containing the filtered morphometrics.
+    overwrite : bool
+        Whether to overwrite the original segmentation mask or save the updated mask to a new file.
+    """
+
+    # first, obtain the instance segmentation
+    if axon_type == 'unmyelinated':
+        target_mask_file = morpho_file.with_name(morpho_file.name.replace('_uaxon_morphometrics.xlsx', '_seg-uaxon.png'))
+        if not target_mask_file.exists():
+            logger.warning(f'Unmyelinated axon segmentation mask {target_mask_file} was not found. Skipping mask update.')
+            return
+        uaxon_pred = imread(target_mask_file)
+        instance_map = measure.label(uaxon_pred, connectivity=1)
+
+    elif axon_type == 'myelinated':
+        axon_myelin_paths = [
+            morpho_file.with_name(morpho_file.name.replace('_axon_morphometrics.xlsx', '_seg-axon.png')),
+            morpho_file.with_name(morpho_file.name.replace('_axon_morphometrics.xlsx', '_seg-myelin.png')),
+        ]
+        if not all(f.exists() for f in axon_myelin_paths):
+            logger.warning(f'The axon and myelin segmentation masks were not found. Skipping mask update.')
+            return
+        im_axon = imread(axon_myelin_paths[0])
+        im_myelin = imread(axon_myelin_paths[1])
+
+        target_instance_map = morpho_file.with_name(morpho_file.name.replace('_axon_morphometrics.xlsx', '_instance-map.png'))
+        if target_instance_map.exists():
+            instance_map = imread(target_instance_map, use_16bit=True)
+        else:
+            logger.warning(f'Myelinated axon instance map {target_instance_map} was not found. Computing instance map from original segmentation masks instead.')
+
+            # duplication of the code in compute_morphometrics.py to get the instance map from the axon and myelin masks
+            im_axon_label = measure.label(im_axon, connectivity=2)
+            axon_objects = measure.regionprops(im_axon_label)
+            index_centroids = (
+                [int(props.centroid[0]) for props in axon_objects],
+                [int(props.centroid[1]) for props in axon_objects],
+            )
+            instance_map = get_watershed_segmentation(im_axon, im_myelin, index_centroids)
+
+    valid_ids = filtered_df.iloc[:, 0].astype(int).values
+    valid_ids = [i + 1 for i in valid_ids]
+    # create a binary mask for invalid axons
+    deletion_mask = np.isin(instance_map, valid_ids, invert=True)
+
+    if axon_type == 'unmyelinated':
+        uaxon_pred[deletion_mask] = 0
+        if overwrite:
+            imwrite(target_mask_file, uaxon_pred)
+            logger.info(f'Overwrote unmyelinated axon segmentation mask: {target_mask_file}')
+        else:
+            new_mask_file = target_mask_file.with_name(target_mask_file.stem + '_filtered.png')
+            imwrite(new_mask_file, uaxon_pred)
+            logger.info(f'Saved updated unmyelinated axon segmentation mask to: {new_mask_file}')
+    elif axon_type == 'myelinated':
+        im_axon[deletion_mask] = 0
+        im_myelin[deletion_mask] = 0
+        if overwrite:
+            target_mask_paths = axon_myelin_paths
+            for mask_file, mask in zip(axon_myelin_paths, [im_axon, im_myelin]):
+                imwrite(mask_file, mask)
+                logger.info(f'Overwrote {mask_file}')
+        else:
+            target_mask_paths = [
+                f.with_name(f.stem + '_filtered.png') for f in axon_myelin_paths
+            ]
+            for new_mask_file, mask in zip(target_mask_paths, [im_axon, im_myelin]):
+                imwrite(new_mask_file, mask)
+                logger.info(f'Saved updated segmentation mask to: {new_mask_file}')
+        # also update the axonmyelin mask
+        merge_masks(*target_mask_paths)
+
+def process_morphometric_files(morpho_files, rules, axon_type, overwrite, update_masks):
+    """
+    Process a list of morphometric files by applying the given filtering rules.
+
+    Parameters
+    ----------
+    morpho_files : tuple of pathlib.Path
+        List of morphometric files to process.
+    rules : list of dict
+        List of filtering rules to apply.
+    axon_type : str
+        Type of axon ('myelinated' or 'unmyelinated').
+    overwrite : bool
+        Whether to overwrite the original files or save the filtered results to new files.
+    update_masks : bool
+        Whether to update the segmentation masks to reflect the filtered morphometrics.
+    """
     logger.info(f'Filtering {axon_type} axons using rules: {rules}')
     for morpho_file in morpho_files:
         df = pd.read_excel(morpho_file)
         original_count = len(df)
+        apply_rules_fn = apply_myelinated_rules if axon_type == 'myelinated' else apply_unmyelinated_rules
         df = apply_rules_fn(df, rules)
         filtered_count = len(df)
         logger.info(f'Filtered {original_count - filtered_count} {axon_type} axons from {morpho_file}.')
@@ -83,6 +189,14 @@ def process_morphometric_files(morpho_files, rules, axon_type, overwrite, apply_
             new_file = morpho_file.with_name(morpho_file.stem + '_filtered.xlsx')
             df.to_excel(new_file, index=False)
             logger.info(f'Saved filtered {axon_type} axons to: {new_file}')
+
+        if update_masks:
+            mask_updater(
+                morpho_file=morpho_file,
+                axon_type=axon_type,
+                filtered_df=df,
+                overwrite=overwrite,
+            )
 
 def main():
     ap = argparse.ArgumentParser()
@@ -128,14 +242,14 @@ def main():
         rules['myelinated'],
         'myelinated',
         args.overwrite,
-        apply_myelinated_rules,
+        args.update_masks,
     )
     process_morphometric_files(
         uaxon_morpho_files,
         rules['unmyelinated'],
         'unmyelinated',
         args.overwrite,
-        apply_unmyelinated_rules,
+        args.update_masks,
     )
 
 

--- a/AxonDeepSeg/morphometrics/filter_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/filter_morphometrics.py
@@ -1,0 +1,144 @@
+"""
+Filter morphometric files based on user-defined constraints. For example, one can remove 
+all axons with invadid g-ratio values (g-ratio >= 1 or g-ratio <= 0) or all axons with a 
+diameter smaller than a given threshold. The segmentation masks can also be updated to 
+reflect the filtered morphometrics.
+"""
+
+import argparse
+from pathlib import Path
+from loguru import logger
+
+import pandas as pd
+import yaml
+
+
+def read_config(config_path: Path) -> dict:
+    '''
+    Read the configuration file containing the filtering criteria
+
+    Parameters
+    ----------
+    config_path : pathlib.Path
+        Path to the configuration file
+
+    Returns
+    -------
+    dict
+        Dictionary containing the filtering criteria for myelinated and unmyelinated axons.
+    '''
+    config_path = Path(config_path)
+    if not config_path.exists():
+        raise FileNotFoundError(f'Configuration file {config_path} does not exist.')
+    
+    with open(str(config_path), 'r') as f:
+        config = yaml.safe_load(f)
+
+    if config.keys() != {'myelinated-rules', 'unmyelinated-rules'}:
+        raise ValueError(f'Configuration file {config_path} must contain "myelinated-rules" and "unmyelinated-rules" keys.')
+    
+    return config
+
+def apply_myelinated_rules(df, rules):
+    for rule in rules:
+        match rule:
+            case {'valid-g-ratio-only': True}:
+                df = df[(df['gratio'] > 0) & (df['gratio'] < 1)]
+                df = df.dropna(subset=['gratio'])
+            case {'axon-diam-gt': threshold} if threshold is not None:
+                df = df[df['axon_diam (um)'] > threshold]
+            case _:
+                logger.warning(f'Unknown rule: {rule}')
+    return df
+
+def apply_unmyelinated_rules(df, rules):
+    for rule in rules:
+        match rule:
+            case {'axon-diam-gt': threshold} if threshold is not None:
+                df = df[df['axon_diam (um)'] > threshold]
+            case {'solidity-gt': threshold} if threshold is not None:
+                df = df[df['solidity'] > threshold]
+            case {'axon-area-lt': threshold} if threshold is not None:
+                df = df[df['axon_area (um^2)'] < threshold]
+            case _:
+                logger.warning(f'Unknown rule: {rule}')
+    return df
+
+def process_morphometric_files(morpho_files, rules, axon_type, overwrite, apply_rules_fn):
+    logger.info(f'Filtering {axon_type} axons using rules: {rules}')
+    for morpho_file in morpho_files:
+        df = pd.read_excel(morpho_file)
+        original_count = len(df)
+        df = apply_rules_fn(df, rules)
+        filtered_count = len(df)
+        logger.info(f'Filtered {original_count - filtered_count} {axon_type} axons from {morpho_file}.')
+
+        # artifact from xlsx import, remove the first column title if required
+        df = df.rename(columns={'Unnamed: 0': ''})
+        
+        if overwrite:
+            df.to_excel(morpho_file, index=False)
+            logger.info(f'Overwrote original file: {morpho_file}')
+        else:
+            new_file = morpho_file.with_name(morpho_file.stem + '_filtered.xlsx')
+            df.to_excel(new_file, index=False)
+            logger.info(f'Saved filtered {axon_type} axons to: {new_file}')
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "-i", "--input", 
+        required=True, 
+        help="Path to the input morphometric file or folder containing morphometric files"
+    )
+    ap.add_argument(
+        "-c", "--config",
+        help="Path to the configuration file containing filtering criteria (defaults to AxonDeepSeg/morphometrics/filter.yaml)" 
+    )
+    ap.add_argument(
+        "-m", "--update_masks",
+        action="store_true",
+        help="Update the segmentation masks to reflect the filtered morphometrics"
+    )
+    ap.add_argument(
+        "-o", "--overwrite",
+        action="store_true",
+        help="Overwrite the original morphometric files (and segmentation masks if -m is set)"
+    )
+
+    args = ap.parse_args()
+
+    # input parsing and validation
+    input_path = Path(args.input)
+    axon_morpho_files = (input_path,) if input_path.is_file() else tuple(input_path.glob("*_axon_morphometrics.xlsx"))
+    logger.info(f'Found {len(axon_morpho_files)} myelinated axon morphometric files to process.')
+
+    uaxon_morpho_files = tuple(Path(str(p).replace('_axon_', '_uaxon_')) for p in axon_morpho_files)
+    uaxon_morpho_files = tuple(p for p in uaxon_morpho_files if p.exists())
+    logger.info(f'Found {len(uaxon_morpho_files)} unmyelinated axon morphometric files to process.')
+
+    if args.config:
+        config_path = Path(args.config)
+    else:
+        config_path = Path(__file__).parent / "filter.yaml"
+    rules = read_config(config_path)
+
+    process_morphometric_files(
+        axon_morpho_files,
+        rules['myelinated-rules'],
+        'myelinated',
+        args.overwrite,
+        apply_myelinated_rules,
+    )
+    process_morphometric_files(
+        uaxon_morpho_files,
+        rules['unmyelinated-rules'],
+        'unmyelinated',
+        args.overwrite,
+        apply_unmyelinated_rules,
+    )
+
+
+if __name__ == "__main__":
+    with logger.catch():
+        main()

--- a/AxonDeepSeg/morphometrics/filter_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/filter_morphometrics.py
@@ -198,7 +198,7 @@ def process_morphometric_files(morpho_files, rules, axon_type, overwrite, update
                 overwrite=overwrite,
             )
 
-def main():
+def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument(
         "-i", "--input", 
@@ -220,7 +220,7 @@ def main():
         help="Overwrite the original morphometric files (and segmentation masks if -m is set)"
     )
 
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     # input parsing and validation
     input_path = Path(args.input)

--- a/AxonDeepSeg/morphometrics/filter_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/filter_morphometrics.py
@@ -51,8 +51,9 @@ def apply_myelinated_rules(df, rules):
             case {'valid-g-ratio-only': True}:
                 df = df[(df['gratio'] > 0) & (df['gratio'] < 1)]
                 df = df.dropna(subset=['gratio'])
-            case {'axon-diam-gt': threshold} if threshold is not None:
-                df = df[df['axon_diam (um)'] > threshold]
+            case {'axon-diam-gt': threshold}:
+                if threshold:
+                    df = df[df['axon_diam (um)'] > threshold]
             case _:
                 logger.warning(f'Unknown rule: {rule}')
     return df
@@ -60,12 +61,15 @@ def apply_myelinated_rules(df, rules):
 def apply_unmyelinated_rules(df, rules):
     for rule in rules:
         match rule:
-            case {'axon-diam-gt': threshold} if threshold is not None:
-                df = df[df['axon_diam (um)'] > threshold]
-            case {'solidity-gt': threshold} if threshold is not None:
-                df = df[df['solidity'] > threshold]
-            case {'axon-area-lt': threshold} if threshold is not None:
-                df = df[df['axon_area (um^2)'] < threshold]
+            case {'axon-diam-gt': threshold}:
+                if threshold:
+                    df = df[df['axon_diam (um)'] > threshold]
+            case {'solidity-gt': threshold}:
+                if threshold:
+                    df = df[df['solidity'] > threshold]
+            case {'axon-area-lt': threshold}:
+                if threshold:
+                    df = df[df['axon_area (um^2)'] < threshold]
             case _:
                 logger.warning(f'Unknown rule: {rule}')
     return df

--- a/AxonDeepSeg/morphometrics/filter_morphometrics.py
+++ b/AxonDeepSeg/morphometrics/filter_morphometrics.py
@@ -74,7 +74,7 @@ def apply_unmyelinated_rules(df, rules):
                 logger.warning(f'Unknown rule: {rule}')
     return df
 
-def mask_updater(morpho_file, axon_type, filtered_df, overwrite):
+def mask_updater(morpho_file, axon_type, filtered_df, overwrite, allow_large_images=False):
     """
     Update the segmentation masks to reflect the filtered morphometrics.
 
@@ -88,6 +88,8 @@ def mask_updater(morpho_file, axon_type, filtered_df, overwrite):
         DataFrame containing the filtered morphometrics.
     overwrite : bool
         Whether to overwrite the original segmentation mask or save the updated mask to a new file.
+    allow_large_images : bool
+        Allow reading masks exceeding PIL's default decompression bomb pixel limit.
     """
 
     # first, obtain the instance segmentation
@@ -96,7 +98,7 @@ def mask_updater(morpho_file, axon_type, filtered_df, overwrite):
         if not target_mask_file.exists():
             logger.warning(f'Unmyelinated axon segmentation mask {target_mask_file} was not found. Skipping mask update.')
             return
-        uaxon_pred = imread(target_mask_file)
+        uaxon_pred = imread(target_mask_file, allow_large_images=allow_large_images)
         instance_map = measure.label(uaxon_pred, connectivity=1)
 
     elif axon_type == 'myelinated':
@@ -107,12 +109,12 @@ def mask_updater(morpho_file, axon_type, filtered_df, overwrite):
         if not all(f.exists() for f in axon_myelin_paths):
             logger.warning(f'The axon and myelin segmentation masks were not found. Skipping mask update.')
             return
-        im_axon = imread(axon_myelin_paths[0])
-        im_myelin = imread(axon_myelin_paths[1])
+        im_axon = imread(axon_myelin_paths[0], allow_large_images=allow_large_images)
+        im_myelin = imread(axon_myelin_paths[1], allow_large_images=allow_large_images)
 
         target_instance_map = morpho_file.with_name(morpho_file.name.replace('_axon_morphometrics.xlsx', '_instance-map.png'))
         if target_instance_map.exists():
-            instance_map = imread(target_instance_map, use_16bit=True)
+            instance_map = imread(target_instance_map, use_16bit=True, allow_large_images=allow_large_images)
         else:
             logger.warning(f'Myelinated axon instance map {target_instance_map} was not found. Computing instance map from original segmentation masks instead.')
 
@@ -157,7 +159,7 @@ def mask_updater(morpho_file, axon_type, filtered_df, overwrite):
         # also update the axonmyelin mask
         merge_masks(*target_mask_paths)
 
-def process_morphometric_files(morpho_files, rules, axon_type, overwrite, update_masks):
+def process_morphometric_files(morpho_files, rules, axon_type, overwrite, update_masks, allow_large_images=False):
     """
     Process a list of morphometric files by applying the given filtering rules.
 
@@ -173,6 +175,8 @@ def process_morphometric_files(morpho_files, rules, axon_type, overwrite, update
         Whether to overwrite the original files or save the filtered results to new files.
     update_masks : bool
         Whether to update the segmentation masks to reflect the filtered morphometrics.
+    allow_large_images : bool
+        Allow reading masks exceeding PIL's default decompression bomb pixel limit.
     """
     logger.info(f'Filtering {axon_type} axons using rules: {rules}')
     for morpho_file in morpho_files:
@@ -200,6 +204,7 @@ def process_morphometric_files(morpho_files, rules, axon_type, overwrite, update
                 axon_type=axon_type,
                 filtered_df=df,
                 overwrite=overwrite,
+                allow_large_images=allow_large_images,
             )
 
 def main(argv=None):
@@ -222,6 +227,15 @@ def main(argv=None):
         "-o", "--overwrite",
         action="store_true",
         help="Overwrite the original morphometric files (and segmentation masks if -m is set)"
+    )
+    ap.add_argument(
+        "--allow-large-images",
+        dest="allow_large_images",
+        required=False,
+        action='store_true',
+        default=False,
+        help='Allow reading masks exceeding PIL\'s default decompression bomb limit '
+             f'(~89 Mpx). \nUse this for large microscopy acquisitions.',
     )
 
     args = ap.parse_args(argv)
@@ -247,6 +261,7 @@ def main(argv=None):
         'myelinated',
         args.overwrite,
         args.update_masks,
+        allow_large_images=args.allow_large_images,
     )
     process_morphometric_files(
         uaxon_morpho_files,
@@ -254,6 +269,7 @@ def main(argv=None):
         'unmyelinated',
         args.overwrite,
         args.update_masks,
+        allow_large_images=args.allow_large_images,
     )
 
 

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -704,17 +704,17 @@ with the suffix ``_filtered.xlsx``::
    axondeepseg_filter -i folder_with_morphometrics
 
 Use ``--config`` to provide a custom rules file, ``--overwrite`` to replace the original files, or ``--update_masks`` to update the corresponding segmentation masks. 
-A custom ``filter.yaml`` file should contain ``myelinated`` and ``unmyelinated`` rule lists. Supported rules include ``valid-g-ratio-only``, ``axon-diam-gt`` (axon diameter greater than), ``solidity-gt`` (solidity greater than), and ``axon-area-lt`` (axon area less than). Use ``~`` as a threshold to disable that rule. Then, pass your custom rules file to the command line with ``--config``::
+A custom **filter.yaml** file should contain *myelinated* and *unmyelinated* rule lists. Supported rules include ``valid-g-ratio-only``, ``axon-diam-gt`` (axon diameter greater than), ``solidity-gt`` (solidity greater than), and ``axon-area-lt`` (axon area less than). Use ``~`` as a threshold to disable that rule. Then, pass your custom rules file to the command line with ``--config``::
 
    axondeepseg_filter -i folder_with_morphometrics --config my_custom_rules.yaml
 
 Axon counting
 ~~~~~~~~~~~~~
-Use ``axondeepseg_count`` to count axons from morphometric files in a folder. Filtered morphometric files are used when available (result of using the ``axondeepseg_filter`` command), and the result is saved to ``axon_counts.csv`` by default::
+Use ``axondeepseg_count`` to count axons from morphometric files in a folder. Filtered morphometric files are used when available (result of using the ``axondeepseg_filter`` command), and the result is saved to **axon_counts.csv** by default::
 
    axondeepseg_count -i folder_with_morphometrics -o counts.csv
 
-To count connected components directly from segmentation masks, add ``--mask_mode``. The folder must contain the expected ``*_seg-axonmyelin.png`` and ``*_seg-uaxon.png`` mask files.
+To count connected components directly from segmentation masks, add ``--mask_mode``. The folder must contain the mask files suffixed by **_seg-axonmyelin.png** and **_seg-uaxon.png**.
 
 .. _quality-assurance-label:
 

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -696,6 +696,26 @@ To aggregate the morphometrics per subject, use the following command::
 
 This will generate a folder called **morphometrics_agg** in the input folder, containing the aggregated morphometrics per subject. It will also contain a short summary file named **statistics_per_axon_caliber.xlsx** which contains basic statistics for axon diameter, myelin thickness and g-ratio. These statistics are computed per axon diameter range.
 
+Morphometrics filtering
+~~~~~~~~~~~~~~~~~~~~~~~
+Use ``axondeepseg_filter`` to remove invalid morphometric measurements from one file or from all morphometric files in a folder. By default, the rules in ``AxonDeepSeg/morphometrics/filter.yaml`` are used and filtered files are saved
+with the suffix ``_filtered.xlsx``::
+
+   axondeepseg_filter -i folder_with_morphometrics
+
+Use ``--config`` to provide a custom rules file, ``--overwrite`` to replace the original files, or ``--update_masks`` to update the corresponding segmentation masks. 
+A custom ``filter.yaml`` file should contain ``myelinated`` and ``unmyelinated`` rule lists. Supported rules include ``valid-g-ratio-only``, ``axon-diam-gt`` (axon diameter greater than), ``solidity-gt`` (solidity greater than), and ``axon-area-lt`` (axon area less than). Use ``~`` as a threshold to disable that rule. Then, pass your custom rules file to the command line with ``--config``::
+
+   axondeepseg_filter -i folder_with_morphometrics --config my_custom_rules.yaml
+
+Axon counting
+~~~~~~~~~~~~~
+Use ``axondeepseg_count`` to count axons from morphometric files in a folder. Filtered morphometric files are used when available (result of using the ``axondeepseg_filter`` command), and the result is saved to ``axon_counts.csv`` by default::
+
+   axondeepseg_count -i folder_with_morphometrics -o counts.csv
+
+To count connected components directly from segmentation masks, add ``--mask_mode``. The folder must contain the expected ``*_seg-axonmyelin.png`` and ``*_seg-uaxon.png`` mask files.
+
 .. _quality-assurance-label:
 
 Quality Assessment (QA) Report

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -703,8 +703,20 @@ with the suffix ``_filtered.xlsx``::
 
    axondeepseg_filter -i folder_with_morphometrics
 
-Use ``--config`` to provide a custom rules file, ``--overwrite`` to replace the original files, or ``--update_masks`` to update the corresponding segmentation masks. 
-A custom **filter.yaml** file should contain *myelinated* and *unmyelinated* rule lists. Supported rules include ``valid-g-ratio-only``, ``axon-diam-gt`` (axon diameter greater than), ``solidity-gt`` (solidity greater than), and ``axon-area-lt`` (axon area less than). Use ``~`` as a threshold to disable that rule. Then, pass your custom rules file to the command line with ``--config``::
+By default, this command will only remove myelinated axons with invalid g-ratios. For more control over the filtering, use ``--config`` to provide a custom rules file, ``--overwrite`` to replace the original files, or ``--update_masks`` to update the corresponding segmentation masks. 
+A custom **filter.yaml** file should contain *myelinated* and *unmyelinated* rule lists. Supported rules include ``valid-g-ratio-only``, ``axon-diam-gt`` (axon diameter greater than), ``solidity-gt`` (solidity greater than), and ``axon-area-lt`` (axon area less than). Use ``~`` as a threshold to disable that rule. This is what an example custom rules file looks like:
+
+.. code-block:: yaml
+
+   myelinated:
+     valid-g-ratio-only: True # <-- axons with g-ratios outside of the ]0,1[ range will be removed; should be True or False
+     axon-diam-gt: 0.5        # <-- axons with diameter less or equal to 0.5 um will be filtered out
+   unmyelinated:
+     axon-diam-gt: ~          # <-- this rule is disabled, so it will not be applied
+     solidity-gt: 0.8         # <-- axons with solidity less or equal to 0.8 will be filtered out
+     axon-area-lt: 2          # <-- axons with area greater or equal to 2 um^2 will be filtered out
+
+Then, pass your custom rules file to the command line with ``--config``::
 
    axondeepseg_filter -i folder_with_morphometrics --config my_custom_rules.yaml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ axondeepseg = "AxonDeepSeg.segment:main"
 axondeepseg_test = "AxonDeepSeg.integrity_test:main"
 axondeepseg_morphometrics = "AxonDeepSeg.morphometrics.launch_morphometrics_computation:main"
 axondeepseg_aggregate = "AxonDeepSeg.morphometrics.aggregate:main"
+axondeepseg_filter = "AxonDeepSeg.morphometrics.filter_morphometrics:main"
+axondeepseg_count = "AxonDeepSeg.morphometrics.count_axons:main"
 
 [tool.setuptools]
 packages = ["AxonDeepSeg"]

--- a/test/morphometrics/test_count_axons.py
+++ b/test/morphometrics/test_count_axons.py
@@ -74,6 +74,27 @@ class TestCore(object):
         }]
 
     @pytest.mark.integration
+    def test_main_counts_images_with_tif_extension(self, tmp_path):
+        image_path = tmp_path / 'sample.tif'
+        image_path.touch()
+
+        pd.DataFrame({'axon_diam (um)': [1]}).to_excel(
+            tmp_path / 'sample_axon_morphometrics.xlsx',
+            index=False,
+        )
+
+        output_path = tmp_path / 'counts.csv'
+        main(['-i', str(tmp_path), '-o', str(output_path)])
+
+        result = pd.read_csv(output_path)
+
+        assert result.to_dict('records') == [{
+            'image': 'sample',
+            'axon_count': 1,
+            'uaxon_count': 0,
+        }]
+
+    @pytest.mark.integration
     def test_main_counts_zero_uaxons_when_uaxon_morphometrics_are_missing(
         self, tmp_path
     ):

--- a/test/morphometrics/test_count_axons.py
+++ b/test/morphometrics/test_count_axons.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from AxonDeepSeg.ads_utils import imwrite
+from AxonDeepSeg.morphometrics.count_axons import main
+
+
+class TestCore(object):
+    def setup_method(self):
+        self.fullPath = Path(__file__).resolve().parent
+        self.testPath = self.fullPath.parent
+
+    def teardown_method(self):
+        pass
+
+    # --------------main integration tests-------------- #
+    @pytest.mark.integration
+    def test_main_counts_morphometric_rows_and_prefers_filtered_files(self, tmp_path):
+        image_path = tmp_path / 'sample.png'
+        image_path.touch()
+
+        pd.DataFrame({'axon_diam (um)': [1, 2]}).to_excel(
+            tmp_path / 'sample_axon_morphometrics.xlsx',
+            index=False,
+        )
+        pd.DataFrame({'axon_diam (um)': [1]}).to_excel(
+            tmp_path / 'sample_axon_morphometrics_filtered.xlsx',
+            index=False,
+        )
+        pd.DataFrame({'axon_diam (um)': [1, 2, 3]}).to_excel(
+            tmp_path / 'sample_uaxon_morphometrics.xlsx',
+            index=False,
+        )
+
+        output_path = tmp_path / 'counts.xlsx.csv'
+        main(['-i', str(tmp_path), '-o', str(output_path)])
+
+        result = pd.read_csv(output_path)
+
+        assert result.to_dict('records') == [{
+            'image': 'sample',
+            'axon_count': 1,
+            'uaxon_count': 3,
+        }]
+
+    @pytest.mark.integration
+    def test_main_counts_connected_components_and_prefers_filtered_masks(self, tmp_path):
+        image = np.zeros((10, 10), dtype=np.uint8)
+        axonmyelin = np.zeros((10, 10), dtype=np.uint8)
+        uaxon = np.zeros((10, 10), dtype=np.uint8)
+        filtered_axonmyelin = np.zeros((10, 10), dtype=np.uint8)
+        filtered_uaxon = np.zeros((10, 10), dtype=np.uint8)
+
+        axonmyelin[1:3, 1:3] = 255
+        axonmyelin[7:9, 7:9] = 255
+        uaxon[1:3, 1:3] = 255
+        uaxon[7:9, 7:9] = 255
+        filtered_axonmyelin[1:3, 1:3] = 255
+        filtered_uaxon[1:3, 1:3] = 255
+
+        imwrite(tmp_path / 'sample.png', image)
+        imwrite(tmp_path / 'sample_seg-axonmyelin.png', axonmyelin)
+        imwrite(tmp_path / 'sample_seg-uaxon.png', uaxon)
+        imwrite(tmp_path / 'sample_seg-axonmyelin_filtered.png', filtered_axonmyelin)
+        imwrite(tmp_path / 'sample_seg-uaxon_filtered.png', filtered_uaxon)
+
+        output_path = tmp_path / 'counts.csv'
+        main(['-i', str(tmp_path), '--mask_mode', '-o', str(output_path)])
+
+        result = pd.read_csv(output_path)
+
+        assert result.to_dict('records') == [{
+            'image': 'sample',
+            'axon_count': 1,
+            'uaxon_count': 1,
+        }]
+
+    @pytest.mark.integration
+    def test_main_writes_empty_counts_csv_for_empty_input_folder(self, tmp_path):
+        output_path = tmp_path / 'counts.csv'
+
+        main(['-i', str(tmp_path), '-o', str(output_path)])
+
+        result = pd.read_csv(output_path)
+
+        assert result.empty
+        assert result.columns.tolist() == ['image', 'axon_count', 'uaxon_count']
+
+    @pytest.mark.exceptionhandling
+    def test_main_raises_for_missing_input_folder(self, tmp_path):
+        with pytest.raises(AssertionError):
+            main(['-i', str(tmp_path / 'missing')])

--- a/test/morphometrics/test_count_axons.py
+++ b/test/morphometrics/test_count_axons.py
@@ -49,6 +49,31 @@ class TestCore(object):
         }]
 
     @pytest.mark.integration
+    def test_main_counts_single_input_file(self, tmp_path):
+        image_path = tmp_path / 'sample.png'
+        image_path.touch()
+
+        pd.DataFrame({'axon_diam (um)': [1]}).to_excel(
+            tmp_path / 'sample_axon_morphometrics.xlsx',
+            index=False,
+        )
+        pd.DataFrame({'axon_diam (um)': [1, 2]}).to_excel(
+            tmp_path / 'sample_uaxon_morphometrics.xlsx',
+            index=False,
+        )
+
+        output_path = tmp_path / 'counts.csv'
+        main(['-i', str(image_path), '-o', str(output_path)])
+
+        result = pd.read_csv(output_path)
+
+        assert result.to_dict('records') == [{
+            'image': 'sample',
+            'axon_count': 1,
+            'uaxon_count': 2,
+        }]
+
+    @pytest.mark.integration
     def test_main_counts_connected_components_and_prefers_filtered_masks(self, tmp_path):
         image = np.zeros((10, 10), dtype=np.uint8)
         axonmyelin = np.zeros((10, 10), dtype=np.uint8)

--- a/test/morphometrics/test_count_axons.py
+++ b/test/morphometrics/test_count_axons.py
@@ -74,6 +74,29 @@ class TestCore(object):
         }]
 
     @pytest.mark.integration
+    def test_main_counts_zero_uaxons_when_uaxon_morphometrics_are_missing(
+        self, tmp_path
+    ):
+        image_path = tmp_path / 'sample.png'
+        image_path.touch()
+
+        pd.DataFrame({'axon_diam (um)': [1]}).to_excel(
+            tmp_path / 'sample_axon_morphometrics.xlsx',
+            index=False,
+        )
+
+        output_path = tmp_path / 'counts.csv'
+        main(['-i', str(image_path), '-o', str(output_path)])
+
+        result = pd.read_csv(output_path)
+
+        assert result.to_dict('records') == [{
+            'image': 'sample',
+            'axon_count': 1,
+            'uaxon_count': 0,
+        }]
+
+    @pytest.mark.integration
     def test_main_counts_connected_components_and_prefers_filtered_masks(self, tmp_path):
         image = np.zeros((10, 10), dtype=np.uint8)
         axonmyelin = np.zeros((10, 10), dtype=np.uint8)
@@ -103,6 +126,26 @@ class TestCore(object):
             'image': 'sample',
             'axon_count': 1,
             'uaxon_count': 1,
+        }]
+
+    @pytest.mark.integration
+    def test_main_counts_zero_uaxons_when_uaxon_mask_is_missing(self, tmp_path):
+        image = np.zeros((10, 10), dtype=np.uint8)
+        axonmyelin = np.zeros((10, 10), dtype=np.uint8)
+        axonmyelin[1:3, 1:3] = 255
+
+        imwrite(tmp_path / 'sample.png', image)
+        imwrite(tmp_path / 'sample_seg-axonmyelin.png', axonmyelin)
+
+        output_path = tmp_path / 'counts.csv'
+        main(['-i', str(tmp_path), '--mask_mode', '-o', str(output_path)])
+
+        result = pd.read_csv(output_path)
+
+        assert result.to_dict('records') == [{
+            'image': 'sample',
+            'axon_count': 1,
+            'uaxon_count': 0,
         }]
 
     @pytest.mark.integration

--- a/test/morphometrics/test_filter_morphometrics.py
+++ b/test/morphometrics/test_filter_morphometrics.py
@@ -1,0 +1,247 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from AxonDeepSeg.morphometrics.filter_morphometrics import (
+	apply_myelinated_rules,
+	apply_unmyelinated_rules,
+	main,
+	read_config,
+)
+
+
+class TestCore(object):
+	def setup_method(self):
+		self.repository_path = Path(__file__).resolve().parents[2]
+		self.default_config_path = (
+			self.repository_path / 'AxonDeepSeg' / 'morphometrics' / 'filter.yaml'
+		)
+
+	# --------------read_config tests-------------- #
+	@pytest.mark.unit
+	def test_read_config_returns_expected_default_rules(self):
+		config = read_config(self.default_config_path)
+
+		assert set(config) == {'myelinated', 'unmyelinated'}
+		assert config['myelinated'] == [
+			{'valid-g-ratio-only': True},
+			{'axon-diam-gt': None},
+		]
+		assert config['unmyelinated'] == [
+			{'axon-diam-gt': None},
+			{'solidity-gt': None},
+			{'axon-area-lt': None},
+		]
+
+	@pytest.mark.unit
+	def test_read_config_raises_for_missing_file(self, tmp_path):
+		with pytest.raises(FileNotFoundError):
+			read_config(tmp_path / 'missing.yaml')
+
+	@pytest.mark.unit
+	def test_read_config_raises_for_invalid_top_level_keys(self, tmp_path):
+		config_path = tmp_path / 'invalid.yaml'
+		config_path.write_text('myelinated: []\nother: []\n')
+
+		with pytest.raises(ValueError):
+			read_config(config_path)
+
+	# --------------apply_myelinated_rules tests-------------- #
+	@pytest.mark.unit
+	def test_apply_myelinated_rules_keeps_only_valid_g_ratios(self):
+		dataframe = pd.DataFrame({
+			'gratio': [0.5, 0, 1, -0.1, np.nan, 0.9],
+			'axon_diam (um)': [1, 2, 3, 4, 5, 6],
+		})
+
+		result = apply_myelinated_rules(
+			dataframe,
+			[{'valid-g-ratio-only': True}],
+		)
+
+		assert result.index.tolist() == [0, 5]
+
+	@pytest.mark.unit
+	def test_apply_myelinated_rules_uses_strict_diameter_threshold(self):
+		dataframe = pd.DataFrame({
+			'gratio': [0.5, 0.5, 0.5],
+			'axon_diam (um)': [5, 10, 15],
+		})
+
+		result = apply_myelinated_rules(
+			dataframe,
+			[{'axon-diam-gt': 10}],
+		)
+
+		assert result.index.tolist() == [2]
+
+	@pytest.mark.unit
+	def test_apply_myelinated_rules_ignores_none_threshold(self):
+		dataframe = pd.DataFrame({
+			'gratio': [0.5, 0.8],
+			'axon_diam (um)': [5, 10],
+		})
+
+		result = apply_myelinated_rules(
+			dataframe,
+			[{'axon-diam-gt': None}],
+		)
+
+		pd.testing.assert_frame_equal(result, dataframe)
+
+	@pytest.mark.unit
+	def test_apply_myelinated_rules_logs_unknown_rule(self):
+		dataframe = pd.DataFrame({'gratio': [0.5]})
+
+		with patch(
+			'AxonDeepSeg.morphometrics.filter_morphometrics.logger.warning'
+		) as warning:
+			result = apply_myelinated_rules(dataframe, [{'unknown-rule': True}])
+
+		pd.testing.assert_frame_equal(result, dataframe)
+		warning.assert_called_once_with("Unknown rule: {'unknown-rule': True}")
+
+	# --------------apply_unmyelinated_rules tests-------------- #
+	@pytest.mark.unit
+	def test_apply_unmyelinated_rules_applies_all_rules(self):
+		dataframe = pd.DataFrame({
+			'axon_diam (um)': [2, 6, 8],
+			'solidity': [0.5, 0.8, 0.95],
+			'axon_area (um^2)': [20, 10, 5],
+		})
+
+		result = apply_unmyelinated_rules(
+			dataframe,
+			[
+				{'axon-diam-gt': 5},
+				{'solidity-gt': 0.7},
+				{'axon-area-lt': 11},
+			],
+		)
+
+		assert result.index.tolist() == [1, 2]
+
+	@pytest.mark.unit
+	def test_apply_unmyelinated_rules_uses_strict_comparisons(self):
+		dataframe = pd.DataFrame({
+			'axon_diam (um)': [5, 6],
+			'solidity': [0.7, 0.8],
+			'axon_area (um^2)': [10, 9],
+		})
+
+		result = apply_unmyelinated_rules(
+			dataframe,
+			[
+				{'axon-diam-gt': 5},
+				{'solidity-gt': 0.7},
+				{'axon-area-lt': 10},
+			],
+		)
+
+		assert result.index.tolist() == [1]
+
+	@pytest.mark.unit
+	def test_apply_unmyelinated_rules_ignores_none_thresholds(self):
+		dataframe = pd.DataFrame({
+			'axon_diam (um)': [5],
+			'solidity': [0.7],
+			'axon_area (um^2)': [10],
+		})
+
+		result = apply_unmyelinated_rules(
+			dataframe,
+			[
+				{'axon-diam-gt': None},
+				{'solidity-gt': None},
+				{'axon-area-lt': None},
+			],
+		)
+
+		pd.testing.assert_frame_equal(result, dataframe)
+
+	@pytest.mark.unit
+	def test_apply_unmyelinated_rules_logs_unknown_rule(self):
+		dataframe = pd.DataFrame({'axon_diam (um)': [5]})
+
+		with patch(
+			'AxonDeepSeg.morphometrics.filter_morphometrics.logger.warning'
+		) as warning:
+			result = apply_unmyelinated_rules(dataframe, [{'unknown-rule': True}])
+
+		pd.testing.assert_frame_equal(result, dataframe)
+		warning.assert_called_once_with("Unknown rule: {'unknown-rule': True}")
+
+	# --------------main integration tests-------------- #
+	@pytest.mark.integration
+	def test_main_filters_myelinated_and_unmyelinated_files_in_folder(
+		self, tmp_path
+	):
+		myelinated_file = tmp_path / 'sample_axon_morphometrics.xlsx'
+		unmyelinated_file = tmp_path / 'sample_uaxon_morphometrics.xlsx'
+		config_file = tmp_path / 'filter.yaml'
+
+		pd.DataFrame({
+			'Unnamed: 0': [0, 1, 2],
+			'gratio': [0.5, 0, 1.1],
+			'axon_diam (um)': [5, 10, 15],
+		}).to_excel(myelinated_file, index=False)
+		pd.DataFrame({
+			'Unnamed: 0': [0, 1, 2],
+			'axon_diam (um)': [2, 6, 8],
+			'solidity': [0.5, 0.8, 0.95],
+			'axon_area (um^2)': [20, 10, 5],
+		}).to_excel(unmyelinated_file, index=False)
+		config_file.write_text(
+			'myelinated:\n'
+			'  - valid-g-ratio-only: true\n'
+			'  - axon-diam-gt: 4\n'
+			'unmyelinated:\n'
+			'  - axon-diam-gt: 5\n'
+			'  - solidity-gt: 0.7\n'
+			'  - axon-area-lt: 11\n'
+		)
+
+		main([
+			'--input', str(tmp_path),
+			'--config', str(config_file),
+		])
+
+		filtered_myelinated = pd.read_excel(
+			tmp_path / 'sample_axon_morphometrics_filtered.xlsx'
+		)
+		filtered_unmyelinated = pd.read_excel(
+			tmp_path / 'sample_uaxon_morphometrics_filtered.xlsx'
+		)
+
+		assert filtered_myelinated['gratio'].tolist() == [0.5]
+		assert filtered_unmyelinated['axon_diam (um)'].tolist() == [6, 8]
+		assert filtered_unmyelinated['solidity'].tolist() == [0.8, 0.95]
+		assert filtered_unmyelinated['axon_area (um^2)'].tolist() == [10, 5]
+
+	@pytest.mark.integration
+	def test_main_overwrites_single_myelinated_file(self, tmp_path):
+		myelinated_file = tmp_path / 'sample_axon_morphometrics.xlsx'
+		config_file = tmp_path / 'filter.yaml'
+
+		pd.DataFrame({
+			'Unnamed: 0': [0, 1],
+			'gratio': [0.5, 1.1],
+			'axon_diam (um)': [5, 10],
+		}).to_excel(myelinated_file, index=False)
+		config_file.write_text(
+			'myelinated:\n'
+			'  - valid-g-ratio-only: true\n'
+			'  - axon-diam-gt: null\n'
+			'unmyelinated: []\n'
+		)
+
+		main([
+			'--input', str(myelinated_file),
+			'--config', str(config_file),
+			'--overwrite',
+		])
+
+		assert not (tmp_path / 'sample_axon_morphometrics_filtered.xlsx').exists()

--- a/test/test_apply_model.py
+++ b/test/test_apply_model.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from AxonDeepSeg.apply_model import (
+    axon_segmentation,
     get_checkpoint_name, 
     extract_from_nnunet_prediction,
     find_folds
@@ -154,3 +155,60 @@ class TestCore(object):
         expected_folds_avail = ['0', '1', '2', '3', '4']
 
         assert folds_avail == expected_folds_avail
+
+    @pytest.mark.unit
+    def test_axon_segmentation_creates_axonmyelin_for_three_classes(
+        self, tmp_path, monkeypatch
+    ):
+        input_path = tmp_path / 'image.png'
+        input_path.touch()
+
+        class FakePredictor:
+            device = 'cpu'
+            dataset_json = {
+                'file_ending': '.png',
+                'labels': {
+                    'background': 0,
+                    'axon': 1,
+                    'other': 2,
+                    'myelin': 3,
+                },
+            }
+
+            def initialize_from_trained_model_folder(
+                self,
+                model_training_output_dir,
+                use_folds,
+                checkpoint_name,
+            ):
+                pass
+
+            def predict_from_files_sequential(
+                self,
+                list_of_lists_or_source_folder,
+                output_folder_or_list_of_truncated_output_files,
+                **kwargs,
+            ):
+                output_path = (
+                    Path(output_folder_or_list_of_truncated_output_files[0])
+                    .with_suffix('.png')
+                )
+                ads_utils.imwrite(output_path, np.array([[0, 1, 2, 3]], dtype=np.uint8))
+
+        monkeypatch.setattr(
+            'AxonDeepSeg.apply_model.AdsPredictor',
+            lambda **kwargs: FakePredictor(),
+        )
+        monkeypatch.setattr(
+            'AxonDeepSeg.apply_model.get_checkpoint_name',
+            lambda path: 'checkpoint_best.pth',
+        )
+
+        axon_segmentation(
+            [input_path],
+            tmp_path,
+            model_type='light',
+            backend='torch',
+        )
+
+        assert (tmp_path / 'image_seg-axonmyelin.png').is_file()


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied [the relevant labels](https://intranet.neuro.polymtl.ca/geek-tips/contributing#pr-labels-a-href-pr-labels-id-pr-labels-a) to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer
- [x] I've consulted [ADS's internal developer documentation](https://github.com/neuropoly/axondeepseg/wiki/Guidelines-for-contribution) to ensure my contribution is in line with any relevant design decisions

## Description
This PR addresses 3 points related to axon counting. The goal was essentially to streamline the process of counting axons, including filtering outliers based on morphometric features.

### 1. Saving "axonmyelin" mask for models with more than 2 output classes
This one is self explanatory. Described in #1003. This was a bug, but it needed fixing for the other 2 features.

### 2. Filtering morphometrics
This was described in #900 but we also discussed it regularly. Filtering the morphometric files is very useful because it can help us spot segmentation artifacts. It is also required to obtain a reliable axon count.

I implemented a new script to do this. The filtering rules are concisely specified in a YAML file. The user can simply modify the values in this config file located in _AxonDeepSeg/morphometrics/filter.yaml_. Currently there are only 5 rules (2 for myelinated axons, 3 for unmyelinated) based on what I was doing on my projects, but we can easily extend it in the future if necessary. This is what the default config file looks like:

```yaml
myelinated:
  - valid-g-ratio-only: True
  - axon-diam-gt: ~

unmyelinated:
  - axon-diam-gt: ~
  - solidity-gt: ~
  - axon-area-lt: ~
```
I purposefully left all values empty because default values would be problematic and, as discussed previously in internal meetings, it's better to let users decide for themselves. The `valid-g-ratio-only` rule is actually enforced by default, because g-ratio values outside of the ]0,1[ range are artifacts. This is the help message for this new script:

```
usage: axondeepseg_filter [-h] -i INPUT [-c CONFIG] [-m] [-o]

options:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        Path to the input morphometric file or folder containing morphometric files
  -c CONFIG, --config CONFIG
                        Path to the configuration file containing filtering criteria (defaults to AxonDeepSeg/morphometrics/filter.yaml)
  -m, --update_masks    Update the segmentation masks to reflect the filtered morphometrics
  -o, --overwrite       Overwrite the original morphometric files (and segmentation masks if -m is set)
```

By default, new morphometric files will be created with the `_filtered.xlsx` suffix. Optionally, note that the script can modify the segmentation masks to reflect the filtering.

### 3. Count axons
Finally, I added a lightweight script to count axons (and prioritize `_filtered` suffixed files when possible) in every image of a given directory. This is useful because it writes a single CSV file with myelinated and unmyelinated axon counts for every image in the directory. Adapted from [this script](https://github.com/axondeepseg-pipeline/model_seg_unmyelinated_tem/blob/main/scripts/utils/count_axons.py).

```
axondeepseg_count -h  
usage: axondeepseg_count [-h] [-i INPUT_DIR] [-m] [-o OUTPUT_NAME]

Count axons (myelinated and unmyelinated, if applicable).

options:
  -h, --help       show this help message and exit
  -i INPUT_DIR     Path to the folder containing all morphometric files.
  -m, --mask_mode  Toggles mask mode: use masks instead of .xlsx to count axons.
  -o OUTPUT_NAME   Name of the output file.
```

This is an example output:
<img width="250" alt="Screenshot 2026-09-03 at 1 45 33 PM" src="https://github.com/user-attachments/assets/2d5b36ea-0d59-4589-98a7-a3ec3219abf8" />


## Linked issues
Fixes #900 
Fixes #1003 
