### PR TITLE
fix: --allow-large-images not wired into axondeepseg_morphometrics

### DIFF
--- a/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
+++ b/AxonDeepSeg/morphometrics/launch_morphometrics_computation.py
@@ -40,7 +40,7 @@ from AxonDeepSeg.params import (
 )
 
 
-def launch_morphometrics_computation(path_img, path_prediction, axon_shape="circle"):
+def launch_morphometrics_computation(path_img, path_prediction, axon_shape="circle", allow_large_images=False):
     """
     This function is equivalent to the morphometrics_extraction notebook of AxonDeepSeg.
     It automatically performs all steps (computations, savings, displays,...) of the
@@ -50,6 +50,8 @@ def launch_morphometrics_computation(path_img, path_prediction, axon_shape="circ
     :param axon_shape: str: shape of the axon, can either be either be circle or an ellipse.
                             if shape of axon = 'circle', equivalent diameter is the diameter of the axon.
                             if shape of axon = 'ellipse', ellipse minor axis is the diameter of the axon.
+    :param allow_large_images: bool: if True, allow reading images exceeding PIL's default
+                            decompression bomb pixel limit.
     :return: none.
     """
 
@@ -59,10 +61,10 @@ def launch_morphometrics_computation(path_img, path_prediction, axon_shape="circ
 
     try:
         # Read image
-        img = ads.imread(path_img)
+        img = ads.imread(path_img, allow_large_images=allow_large_images)
 
         # Read prediction
-        pred = ads.imread(path_prediction)
+        pred = ads.imread(path_prediction, allow_large_images=allow_large_images)
     except (IOError, OSError) as e:
         print(("launch_morphometrics_computation: " + str(e)))
         raise
@@ -90,19 +92,21 @@ def launch_morphometrics_computation(path_img, path_prediction, axon_shape="circ
         write_aggregate_morphometrics(path_folder, aggregate_metrics)
 
 
-def load_mask(current_path_target: Path, semantic_class: str, suffix: str):
+def load_mask(current_path_target: Path, semantic_class: str, suffix: str, allow_large_images: bool = False):
     """
-    This function loads a mask based on the provided suffix. Will stop execution 
+    This function loads a mask based on the provided suffix. Will stop execution
     with exit code 3 if the mask is not found.
 
     :param current_path_target: Path of the target image
     :param semantic_class: Semantic class of the mask to load ('axon', 'myelin' or 'unmyelinated axon')
     :param suffix: Suffix to determine which mask to load
+    :param allow_large_images: bool: if True, allow reading masks exceeding PIL's default
+                            decompression bomb pixel limit.
     :return: Loaded mask image
     """
     mask_path = Path(str(current_path_target.with_suffix("")) + str(suffix))
     if mask_path.exists():
-        return ads.imread(str(mask_path))
+        return ads.imread(str(mask_path), allow_large_images=allow_large_images)
     else:
         msg = f"ERROR: Segmented {semantic_class} mask for image: `{str(current_path_target)}` " \
             f"is not present in the image folder. Please check that the {semantic_class} mask is " \
@@ -171,6 +175,15 @@ def main(argv=None):
             +'Works for myelinated axons with axon_shape="circle" or axon_shape="ellipse". \n'
             +'Skipped for unmyelinated and nerve modes.'
     )
+    ap.add_argument(
+        "--allow-large-images",
+        dest="allow_large_images",
+        required=False,
+        action='store_true',
+        default=False,
+        help='Allow morphometrics computation on images exceeding PIL\'s default decompression bomb limit '
+             f'(~178 Mpx). \nUse this for large microscopy acquisitions.',
+    )
 
     # Processing the arguments
     args = vars(ap.parse_args(argv))
@@ -181,6 +194,7 @@ def main(argv=None):
     unmyelinated_mode = args["unmyelinated"]
     nerve_mode = args["nerve"]
     diameter_overlay_flag = args["diameter_overlay"]
+    allow_large_images = args["allow_large_images"]
     if nerve_mode:
         morphometrics_mode = 'nerve'
         target_suffix = nerve_suffix
@@ -251,17 +265,17 @@ def main(argv=None):
             match morphometrics_mode:
                 case 'myelinated':
                     # load the axon and myelin masks
-                    pred_axon = load_mask(current_path_target, 'axon', axon_suffix)
-                    pred_myelin = load_mask(current_path_target, 'myelin', myelin_suffix)
+                    pred_axon = load_mask(current_path_target, 'axon', axon_suffix, allow_large_images=allow_large_images)
+                    pred_myelin = load_mask(current_path_target, 'myelin', myelin_suffix, allow_large_images=allow_large_images)
                 case 'unmyelinated':
                     # load the unmyelinated axon mask
-                    pred_uaxon = load_mask(current_path_target, 'unmyelinated axon', unmyelinated_suffix)
+                    pred_uaxon = load_mask(current_path_target, 'unmyelinated axon', unmyelinated_suffix, allow_large_images=allow_large_images)
                 case 'nerve':
                     # load the nerve mask
-                    pred_nerve = load_mask(current_path_target, 'nerve', nerve_suffix)
+                    pred_nerve = load_mask(current_path_target, 'nerve', nerve_suffix, allow_large_images=allow_large_images)
                     # also load axon and myelin masks for removal process
-                    pred_axon = load_mask(current_path_target, 'axon', axon_suffix)
-                    pred_myelin = load_mask(current_path_target, 'myelin', myelin_suffix)
+                    pred_axon = load_mask(current_path_target, 'axon', axon_suffix, allow_large_images=allow_large_images)
+                    pred_myelin = load_mask(current_path_target, 'myelin', myelin_suffix, allow_large_images=allow_large_images)
 
 
             if args["sizepixel"] is not None:
@@ -339,7 +353,8 @@ def main(argv=None):
                 postprocessing.generate_and_save_colored_image_with_index_numbers(
                     filename=index_overlay_fname,
                     axonmyelin_image_path=bg_image_path,
-                    index_image_array=index_image_array
+                    index_image_array=index_image_array,
+                    allow_large_images=allow_large_images,
                 )
                 
                 if colorization_flag:

--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -9,7 +9,7 @@ from matplotlib import font_manager
 from loguru import logger
 
 from AxonDeepSeg import params
-from AxonDeepSeg.ads_utils import convert_path, imwrite
+from AxonDeepSeg.ads_utils import convert_path, imwrite, _LARGE_IMAGE_PIXEL_LIMIT
 import AxonDeepSeg.morphometrics.compute_morphometrics as compute_morphs
 
 def get_centroids(mask):
@@ -127,7 +127,7 @@ def generate_axon_numbers_image(centroid_index, x0_array, y0_array, image_size, 
 
     return image_array.astype(np.uint8)
 
-def generate_and_save_colored_image_with_index_numbers(filename, axonmyelin_image_path, index_image_array):
+def generate_and_save_colored_image_with_index_numbers(filename, axonmyelin_image_path, index_image_array, allow_large_images=False):
     """
     This function generates an RGB image with the axons in blue and myelin in red with the axon indexes overlayed on
     top of the image.
@@ -137,15 +137,23 @@ def generate_and_save_colored_image_with_index_numbers(filename, axonmyelin_imag
     :type axonmyelin_image_path: String or Path
     :param index_image_array: The array containing the index image
     :type index_image_array: 2D Numpy array
+    :param allow_large_images: bool: if True, allow processing images exceeding PIL's default
+        decompression bomb pixel limit.
     """
-    seg = Image.open(axonmyelin_image_path)
-    index_image = Image.fromarray(index_image_array)
-    colored_image = ImageOps.colorize(seg, black="black", white="blue", mid="red",
-                                      blackpoint=params.intensity["background"],
-                                      whitepoint=params.intensity["axon"],
-                                      midpoint=params.intensity["myelin"])
-    colored_image.paste(index_image, mask=index_image)
-    colored_image.save(filename)
+    old_limit = Image.MAX_IMAGE_PIXELS
+    if allow_large_images:
+        Image.MAX_IMAGE_PIXELS = _LARGE_IMAGE_PIXEL_LIMIT
+    try:
+        seg = Image.open(axonmyelin_image_path)
+        index_image = Image.fromarray(index_image_array)
+        colored_image = ImageOps.colorize(seg, black="black", white="blue", mid="red",
+                                          blackpoint=params.intensity["background"],
+                                          whitepoint=params.intensity["axon"],
+                                          midpoint=params.intensity["myelin"])
+        colored_image.paste(index_image, mask=index_image)
+        colored_image.save(filename)
+    finally:
+        Image.MAX_IMAGE_PIXELS = old_limit
 
 def remove_axons_at_coordinates(im_axon, im_myelin, x0s, y0s):
     """

--- a/AxonDeepSeg/postprocessing.py
+++ b/AxonDeepSeg/postprocessing.py
@@ -9,7 +9,7 @@ from matplotlib import font_manager
 from loguru import logger
 
 from AxonDeepSeg import params
-from AxonDeepSeg.ads_utils import convert_path, imwrite, _LARGE_IMAGE_PIXEL_LIMIT
+from AxonDeepSeg.ads_utils import convert_path, imread, imwrite
 import AxonDeepSeg.morphometrics.compute_morphometrics as compute_morphs
 
 def get_centroids(mask):
@@ -140,20 +140,14 @@ def generate_and_save_colored_image_with_index_numbers(filename, axonmyelin_imag
     :param allow_large_images: bool: if True, allow processing images exceeding PIL's default
         decompression bomb pixel limit.
     """
-    old_limit = Image.MAX_IMAGE_PIXELS
-    if allow_large_images:
-        Image.MAX_IMAGE_PIXELS = _LARGE_IMAGE_PIXEL_LIMIT
-    try:
-        seg = Image.open(axonmyelin_image_path)
-        index_image = Image.fromarray(index_image_array)
-        colored_image = ImageOps.colorize(seg, black="black", white="blue", mid="red",
-                                          blackpoint=params.intensity["background"],
-                                          whitepoint=params.intensity["axon"],
-                                          midpoint=params.intensity["myelin"])
-        colored_image.paste(index_image, mask=index_image)
-        colored_image.save(filename)
-    finally:
-        Image.MAX_IMAGE_PIXELS = old_limit
+    seg = Image.fromarray(imread(axonmyelin_image_path, allow_large_images=allow_large_images))
+    index_image = Image.fromarray(index_image_array)
+    colored_image = ImageOps.colorize(seg, black="black", white="blue", mid="red",
+                                      blackpoint=params.intensity["background"],
+                                      whitepoint=params.intensity["axon"],
+                                      midpoint=params.intensity["myelin"])
+    colored_image.paste(index_image, mask=index_image)
+    colored_image.save(filename)
 
 def remove_axons_at_coordinates(im_axon, im_myelin, x0s, y0s):
     """

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -379,6 +379,9 @@ The script to launch is called **axondeepseg_morphometrics**. It has several arg
 
 -d                  Generate a diameter overlay image showing concentric circle or ellipse outlines for each myelinated axon (inner ring = axon boundary, outer ring = fiber boundary). Only available in myelinated mode (not compatible with ``-u`` or ``-n``). The axon shape used for the overlay matches the ``-a`` argument. Output is saved with the suffix ``_diameter_overlay.png``.
 
+--allow-large-images
+                    Allow morphometrics computation on images that exceed PIL's default decompression bomb pixel limit (~89 million pixels). Use this flag when processing very large microscopy images that would otherwise be rejected.
+
 Morphometrics of a single image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Before computing the morphometrics of an image, make sure it has been segmented using AxonDeepSeg ::

--- a/test/morphometrics/test_launch_morphometrics_computation.py
+++ b/test/morphometrics/test_launch_morphometrics_computation.py
@@ -106,6 +106,41 @@ class TestCore(object):
         with pytest.raises((IOError, OSError)):
             launch_morphometrics_computation(str(nonExistingFile), str(pathPrediction))
 
+    # --------------load_mask tests-------------- #
+    @pytest.mark.unit
+    def test_load_mask_forwards_allow_large_images_true_to_imread(self, monkeypatch):
+        pathImg = self.dataPath / 'image.png'
+
+        captured = {}
+        original_imread = ads.imread
+        def fake_imread(filename, *args, **kwargs):
+            captured['allow_large_images'] = kwargs.get('allow_large_images')
+            return original_imread(filename)
+        monkeypatch.setattr(ads, 'imread', fake_imread)
+
+        AxonDeepSeg.morphometrics.launch_morphometrics_computation.load_mask(
+            pathImg, 'axon', axon_suffix, allow_large_images=True
+        )
+
+        assert captured['allow_large_images'] is True
+
+    @pytest.mark.unit
+    def test_load_mask_defaults_to_disallowing_large_images(self, monkeypatch):
+        pathImg = self.dataPath / 'image.png'
+
+        captured = {}
+        original_imread = ads.imread
+        def fake_imread(filename, *args, **kwargs):
+            captured['allow_large_images'] = kwargs.get('allow_large_images')
+            return original_imread(filename)
+        monkeypatch.setattr(ads, 'imread', fake_imread)
+
+        AxonDeepSeg.morphometrics.launch_morphometrics_computation.load_mask(
+            pathImg, 'axon', axon_suffix
+        )
+
+        assert captured['allow_large_images'] is False
+
     # --------------main (cli) tests-------------- #
     @pytest.mark.unit
     def test_main_cli_runs_successfully_with_valid_inputs(self):

--- a/test/test_postprocessing.py
+++ b/test/test_postprocessing.py
@@ -4,6 +4,7 @@ import pytest
 from pathlib import Path
 import numpy as np
 import pandas as pd
+import imageio
 from PIL import Image
 
 from skimage.measure import regionprops, label
@@ -107,6 +108,38 @@ class TestCore(object):
         # Load the created image and compare it to the expected image
         output_image = np.asarray(Image.open(output_image_path))
         assert np.array_equal(output_image, expected_image)
+
+    @pytest.mark.unit
+    def test_generate_and_save_colored_image_with_index_numbers_raises_for_huge_image_by_default(self, tmp_path):
+        # 14000x14000 pixels exceeds PIL's decompression bomb error threshold
+        # (2x its default MAX_IMAGE_PIXELS), so this must be rejected by default.
+        large_image_path = tmp_path / "huge_axonmyelin.png"
+        output_image_path = tmp_path / "huge_output.png"
+        imageio.imwrite(large_image_path, np.zeros((14000, 14000), dtype=np.uint8))
+        index_array = np.zeros((14000, 14000), dtype=np.uint8)
+
+        with pytest.raises(Image.DecompressionBombError):
+            postprocessing.generate_and_save_colored_image_with_index_numbers(
+                filename=output_image_path,
+                axonmyelin_image_path=large_image_path,
+                index_image_array=index_array,
+            )
+
+    @pytest.mark.unit
+    def test_generate_and_save_colored_image_with_index_numbers_succeeds_for_huge_image_when_allow_large_images_is_true(self, tmp_path):
+        large_image_path = tmp_path / "huge_axonmyelin.png"
+        output_image_path = tmp_path / "huge_output.png"
+        imageio.imwrite(large_image_path, np.zeros((14000, 14000), dtype=np.uint8))
+        index_array = np.zeros((14000, 14000), dtype=np.uint8)
+
+        postprocessing.generate_and_save_colored_image_with_index_numbers(
+            filename=output_image_path,
+            axonmyelin_image_path=large_image_path,
+            index_image_array=index_array,
+            allow_large_images=True,
+        )
+
+        assert output_image_path.exists()
 
     @pytest.mark.unit
     def test_generate_rotated_ellipse_points_returns_requested_number_of_points(self):

--- a/test/test_postprocessing.py
+++ b/test/test_postprocessing.py
@@ -111,14 +111,14 @@ class TestCore(object):
 
     @pytest.mark.unit
     def test_generate_and_save_colored_image_with_index_numbers_raises_for_huge_image_by_default(self, tmp_path):
-        # 14000x14000 pixels exceeds PIL's decompression bomb error threshold
-        # (2x its default MAX_IMAGE_PIXELS), so this must be rejected by default.
+        # 10000x10000 pixels exceeds PIL's default MAX_IMAGE_PIXELS (~89 million),
+        # so this must be rejected by default via ads_utils.imread's explicit check.
         large_image_path = tmp_path / "huge_axonmyelin.png"
         output_image_path = tmp_path / "huge_output.png"
-        imageio.imwrite(large_image_path, np.zeros((14000, 14000), dtype=np.uint8))
-        index_array = np.zeros((14000, 14000), dtype=np.uint8)
+        imageio.imwrite(large_image_path, np.zeros((10000, 10000), dtype=np.uint8))
+        index_array = np.zeros((10000, 10000), dtype=np.uint8)
 
-        with pytest.raises(Image.DecompressionBombError):
+        with pytest.raises(IOError):
             postprocessing.generate_and_save_colored_image_with_index_numbers(
                 filename=output_image_path,
                 axonmyelin_image_path=large_image_path,
@@ -129,8 +129,8 @@ class TestCore(object):
     def test_generate_and_save_colored_image_with_index_numbers_succeeds_for_huge_image_when_allow_large_images_is_true(self, tmp_path):
         large_image_path = tmp_path / "huge_axonmyelin.png"
         output_image_path = tmp_path / "huge_output.png"
-        imageio.imwrite(large_image_path, np.zeros((14000, 14000), dtype=np.uint8))
-        index_array = np.zeros((14000, 14000), dtype=np.uint8)
+        imageio.imwrite(large_image_path, np.zeros((10000, 10000), dtype=np.uint8))
+        index_array = np.zeros((10000, 10000), dtype=np.uint8)
 
         postprocessing.generate_and_save_colored_image_with_index_numbers(
             filename=output_image_path,


### PR DESCRIPTION
`axondeepseg_morphometrics` never exposed `--allow-large-images`, so `load_mask()` always called `ads.imread()` with the default `allow_large_images=False` and crashed on large images. `postprocessing.generate_and_save_colored_image_with_index_numbers()` had the same problem in a sneakier way: it calls `Image.open()` directly instead of going through `ads_utils`, so it bypassed the mechanism entirely.

Fix: add the same `--allow-large-images` flag `segment.py` already has, thread it through `load_mask()` and the colored index image generator.

Doesn't touch `filter_morphometrics.py`/`count_axons.py` from #1005 since those don't exist on master yet.

Refs #990